### PR TITLE
[service] Do not start autoconnect round without a back-off timer. JB#52947

### DIFF
--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -5648,8 +5648,8 @@ static gboolean service_retry_connect(gpointer data)
 	DBG("service %p", service);
 	service->connect_retry_timer = 0;
 
-	if (service->state == CONNMAN_SERVICE_STATE_FAILURE) {
-
+	if (service->state == CONNMAN_SERVICE_STATE_FAILURE ||
+			service->state == CONNMAN_SERVICE_STATE_IDLE) {
 		/*
 		 * Do not reset VPN state here as doing so leads to reseting of
 		 * the VPN autoconnect timer without proper reason.

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -5068,9 +5068,6 @@ static void service_complete(struct connman_service *service)
 {
 	reply_pending(service, EIO);
 
-	if (service->connect_reason != CONNMAN_SERVICE_CONNECT_REASON_USER)
-		do_auto_connect(service, service->connect_reason);
-
 	update_modified(service);
 	service_save(service);
 }


### PR DESCRIPTION
The timer was made to trigger autoconnect round for services that are
in failed state. However, the cellular service does not stay in the failed
state for long and goes idle right after the timer is started due to
gofono's "activate-failed" signal being triggered.

This PR includes two commits: the first makes autoconnect round to start
regardless the service is in idle state, and the second does not allow auto
connection bypassing the back off timer.