### PR TITLE
Improve invalid auth and disconnect notify, fix cb use in PPPD based VPN plugins

### DIFF
--- a/connman/vpn/plugins/l2tp.c
+++ b/connman/vpn/plugins/l2tp.c
@@ -4,7 +4,7 @@
  *
  *  Copyright (C) 2010,2013  BMW Car IT GmbH.
  *  Copyright (C) 2012-2013  Intel Corporation. All rights reserved.
- *  Copyright (C) 2019  Jolla Ltd.
+ *  Copyright (C) 2019-2021  Jolla Ltd.
  *  Copyright (C) 2019  Open Mobile Platform LLC.
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -125,11 +125,39 @@ struct {
 static DBusConnection *connection;
 
 struct l2tp_private_data {
+	struct vpn_provider *provider;
 	struct connman_task *task;
 	char *if_name;
 	vpn_provider_connect_cb_t cb;
 	void *user_data;
 };
+
+static void l2tp_connect_done(struct l2tp_private_data *data, int err)
+{
+	vpn_provider_connect_cb_t cb;
+	void *user_data;
+
+	if (!data || !data->cb)
+		return;
+
+	/* Ensure that callback is called only once */
+	cb = data->cb;
+	user_data = data->user_data;
+	data->cb = NULL;
+	data->user_data = NULL;
+	cb(data->provider, user_data, err);
+}
+
+static void free_private_data(struct l2tp_private_data *data)
+{
+	if (vpn_provider_get_plugin_data(data->provider) == data)
+		vpn_provider_set_plugin_data(data->provider, NULL);
+
+	l2tp_connect_done(data, EIO);
+	vpn_provider_unref(data->provider);
+	g_free(data->if_name);
+	g_free(data);
+}
 
 static DBusMessage *l2tp_get_sec(struct connman_task *task,
 			DBusMessage *msg, void *user_data)
@@ -168,6 +196,9 @@ static int l2tp_notify(DBusMessage *msg, struct vpn_provider *provider)
 	char *addressv4 = NULL, *netmask = NULL, *gateway = NULL;
 	char *ifname = NULL, *nameservers = NULL;
 	struct connman_ipaddress *ipaddress = NULL;
+	struct l2tp_private_data *data;
+
+	data = vpn_provider_get_plugin_data(provider);
 
 	dbus_message_iter_init(msg, &iter);
 
@@ -186,11 +217,22 @@ static int l2tp_notify(DBusMessage *msg, struct vpn_provider *provider)
 		vpn_provider_set_string_hide_value(provider, "L2TP.Password",
 					NULL);
 
+		l2tp_connect_done(data, EACCES);
 		return VPN_STATE_AUTH_FAILURE;
 	}
 
-	if (strcmp(reason, "connect"))
+	if (strcmp(reason, "connect")) {
+		l2tp_connect_done(data, EIO);
+
+		/*
+		 * Stop the task to avoid potential looping of this state when
+		 * authentication fails.
+		 */
+		if (data && data->task)
+			connman_task_stop(data->task);
+
 		return VPN_STATE_DISCONNECT;
+	}
 
 	dbus_message_iter_recurse(&iter, &dict);
 
@@ -260,6 +302,8 @@ static int l2tp_notify(DBusMessage *msg, struct vpn_provider *provider)
 	g_free(gateway);
 	g_free(nameservers);
 	connman_ipaddress_free(ipaddress);
+
+	l2tp_connect_done(data, 0);
 
 	return VPN_STATE_CONNECT;
 }
@@ -488,9 +532,10 @@ static int l2tp_write_config(struct vpn_provider *provider,
 
 static void l2tp_died(struct connman_task *task, int exit_code, void *user_data)
 {
+	struct l2tp_private_data *data = user_data;
 	char *conf_file;
 
-	vpn_died(task, exit_code, user_data);
+	vpn_died(task, exit_code, data->provider);
 
 	conf_file = g_strconcat(VPN_STATEDIR, "/connman-xl2tpd.conf", NULL);
 	unlink(conf_file);
@@ -499,6 +544,8 @@ static void l2tp_died(struct connman_task *task, int exit_code, void *user_data)
 	conf_file = g_strconcat(VPN_STATEDIR, "/connman-ppp-option.conf", NULL);
 	unlink(conf_file);
 	g_free(conf_file);
+
+	free_private_data(data);
 }
 
 struct request_input_reply {
@@ -658,11 +705,11 @@ static int request_input(struct vpn_provider *provider,
 	return -EINPROGRESS;
 }
 
-static int run_connect(struct vpn_provider *provider,
-			struct connman_task *task, const char *if_name,
-			vpn_provider_connect_cb_t cb, void *user_data,
+static int run_connect(struct l2tp_private_data *data,
 			const char *username, const char *password)
 {
+	struct vpn_provider *provider = data->provider;
+	struct connman_task *task = data->task;
 	char *l2tp_name, *ctrl_name, *pppd_name;
 	int l2tp_fd, pppd_fd;
 	int err;
@@ -724,25 +771,17 @@ static int run_connect(struct vpn_provider *provider,
 	close(l2tp_fd);
 	close(pppd_fd);
 
-	err = connman_task_run(task, l2tp_died, provider,
-				NULL, NULL, NULL);
+	err = connman_task_run(task, l2tp_died, data, NULL, NULL, NULL);
 	if (err < 0) {
 		connman_error("l2tp failed to start");
 		err = -EIO;
-		goto done;
 	}
 
 done:
-	if (cb)
-		cb(provider, user_data, err);
+	if (err)
+		l2tp_connect_done(data, -err);
 
 	return err;
-}
-
-static void free_private_data(struct l2tp_private_data *data)
-{
-	g_free(data->if_name);
-	g_free(data);
 }
 
 static void request_input_cb(struct vpn_provider *provider,
@@ -762,10 +801,7 @@ static void request_input_cb(struct vpn_provider *provider,
 	vpn_provider_set_string_hide_value(provider, "L2TP.Password",
 								password);
 
-	run_connect(provider, data->task, data->if_name, data->cb,
-		data->user_data, username, password);
-
-	free_private_data(data);
+	run_connect(data, username, password);
 }
 
 static int l2tp_connect(struct vpn_provider *provider,
@@ -773,8 +809,20 @@ static int l2tp_connect(struct vpn_provider *provider,
 			vpn_provider_connect_cb_t cb, const char *dbus_sender,
 			void *user_data)
 {
+	struct l2tp_private_data *data;
 	const char *username, *password;
 	int err;
+
+	data = g_try_new0(struct l2tp_private_data, 1);
+	if (!data)
+		return -ENOMEM;
+
+	data->provider = vpn_provider_ref(provider);
+	data->task = task;
+	data->if_name = g_strdup(if_name);
+	data->cb = cb;
+	data->user_data = user_data;
+	vpn_provider_set_plugin_data(provider, data);
 
 	if (connman_task_set_notify(task, "getsec",
 					l2tp_get_sec, provider) != 0) {
@@ -788,33 +836,19 @@ static int l2tp_connect(struct vpn_provider *provider,
 	DBG("user %s password %p", username, password);
 
 	if (!username || !*username || !password || !*password) {
-		struct l2tp_private_data *data;
-
-		data = g_try_new0(struct l2tp_private_data, 1);
-		if (!data)
-			return -ENOMEM;
-
-		data->task = task;
-		data->if_name = g_strdup(if_name);
-		data->cb = cb;
-		data->user_data = user_data;
-
 		err = request_input(provider, request_input_cb, dbus_sender,
 									data);
-		if (err != -EINPROGRESS) {
-			free_private_data(data);
-			goto done;
-		}
+		if (err != -EINPROGRESS)
+			goto error;
+
 		return err;
 	}
 
-done:
-	return run_connect(provider, task, if_name, cb, user_data,
-							username, password);
+	return run_connect(data, username, password);
 
 error:
-	if (cb)
-		cb(provider, user_data, err);
+	l2tp_connect_done(data, -err);
+	free_private_data(data);
 
 	return err;
 }


### PR DESCRIPTION
[l2tp] Improve invalid auth and disconnect notify, fix cb use. JB#52482
[pptp] Improve invalid auth and disconnect notify, fix cb use. JB#52482
[openfortivpn] Improve invalid auth and disconnect notify, fix cb use. JB#52482

All follow the same codebase, same fixes apply to all. This fixes issue of VPN not dying in case the auth is invalid.

These changes enforce quitting of the VPN plugin when it is being disconnected, also because of invalid authentication and then prompts for new password via VPN agent. These fix premature calling of the connect callback before connection status is being evaluated at all. Other minor cleanups and fixes here and there.

Slight increase in memory consumption because of storing the private variables for the duration of the connection. It seems that these three plugins would greatly benefit from a few generalized helper/util/lib functions.

