### PR TITLE
Fix IPv4 not working properly on dual mode cellular

### DIFF
--- a/connman/gdhcp/client.c
+++ b/connman/gdhcp/client.c
@@ -2406,6 +2406,9 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 		dhcp_client->retry_times = 0;
 
 		option = dhcp_get_option(&packet, pkt_len, DHCP_SERVER_ID);
+		if (!option)
+			return TRUE;
+
 		dhcp_client->server_ip = get_be32(option);
 		dhcp_client->requested_ip = ntohl(packet.yiaddr);
 
@@ -2467,6 +2470,8 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 			if (dhcp_client->state == REBOOTING) {
 				option = dhcp_get_option(&packet, pkt_len,
 							DHCP_SERVER_ID);
+				if (!option)
+					return TRUE;
 				dhcp_client->server_ip = get_be32(option);
 			}
 

--- a/connman/gdhcp/client.c
+++ b/connman/gdhcp/client.c
@@ -554,7 +554,8 @@ static int send_request(GDHCPClient *dhcp_client)
 	if (dhcp_client->state == RENEWING)
 		return dhcp_send_kernel_packet(&packet,
 				dhcp_client->requested_ip, CLIENT_PORT,
-				dhcp_client->server_ip, SERVER_PORT);
+				dhcp_client->server_ip, SERVER_PORT,
+				dhcp_client->interface);
 
 	return dhcp_send_raw_packet(&packet, INADDR_ANY, CLIENT_PORT,
 				INADDR_BROADCAST, SERVER_PORT,
@@ -578,7 +579,8 @@ static int send_release(GDHCPClient *dhcp_client,
 	dhcp_add_option_uint32(&packet, DHCP_SERVER_ID, server);
 
 	return dhcp_send_kernel_packet(&packet, ciaddr, CLIENT_PORT,
-						server, SERVER_PORT);
+						server, SERVER_PORT,
+						dhcp_client->interface);
 }
 
 static gboolean ipv4ll_probe_timeout(gpointer dhcp_data);

--- a/connman/gdhcp/common.h
+++ b/connman/gdhcp/common.h
@@ -209,7 +209,8 @@ int dhcp_send_raw_packet(struct dhcp_packet *dhcp_pkt,
 int dhcpv6_send_packet(int index, struct dhcpv6_packet *dhcp_pkt, int len);
 int dhcp_send_kernel_packet(struct dhcp_packet *dhcp_pkt,
 			uint32_t source_ip, int source_port,
-			uint32_t dest_ip, int dest_port);
+			uint32_t dest_ip, int dest_port,
+			const char *interface);
 int dhcp_l3_socket(int port, const char *interface, int family);
 int dhcp_recv_l3_packet(struct dhcp_packet *packet, int fd);
 int dhcpv6_recv_l3_packet(struct dhcpv6_packet **packet, unsigned char *buf,

--- a/connman/include/network.h
+++ b/connman/include/network.h
@@ -103,6 +103,9 @@ bool connman_network_get_connected(struct connman_network *network);
 
 bool connman_network_get_associating(struct connman_network *network);
 
+bool connman_network_is_configured(struct connman_network *network,
+					enum connman_ipconfig_type type);
+
 void connman_network_clear_hidden(void *user_data);
 int connman_network_connect_hidden(struct connman_network *network,
 			char *identity, char* passphrase, void *user_data);

--- a/connman/include/network.h
+++ b/connman/include/network.h
@@ -116,6 +116,8 @@ void connman_network_set_ipv6_method(struct connman_network *network,
 					enum connman_ipconfig_method method);
 int connman_network_set_ipaddress(struct connman_network *network,
 				struct connman_ipaddress *ipaddress);
+void connman_network_clear_ipaddress(struct connman_network *network,
+					enum connman_ipconfig_type type);
 int connman_network_set_nameservers(struct connman_network *network,
 				const char *nameservers);
 int connman_network_set_domain(struct connman_network *network,

--- a/connman/include/network.h
+++ b/connman/include/network.h
@@ -89,6 +89,7 @@ void connman_network_set_group(struct connman_network *network,
 const char *connman_network_get_group(struct connman_network *network);
 
 bool connman_network_get_connecting(struct connman_network *network);
+bool connman_network_get_disconnecting(struct connman_network *network);
 int connman_network_set_available(struct connman_network *network,
 						bool available);
 bool connman_network_get_available(struct connman_network *network);

--- a/connman/plugins/sailfish_ofono.c
+++ b/connman/plugins/sailfish_ofono.c
@@ -98,6 +98,10 @@ enum connctx_handler_id {
 /* Should be less than CONNECT_TIMEOUT defined in service.c (currently 120) */
 #define ACTIVATE_TIMEOUT_SEC (60)
 #define ONLINE_CHECK_SEC  (2)
+/* Timeout for delayed set connected call, in milliseconds. */
+#define DELAYED_CONNECT_TIMEOUT_MS (100)
+/* Wait for approx 2s for address information from ofono. */
+#define DELAYED_CONNECT_LIMIT (2000 / DELAYED_CONNECT_TIMEOUT_MS)
 
 struct modem_data {
 	OfonoModem *modem;
@@ -121,6 +125,8 @@ struct modem_data {
 	guint strength;
 	char *name;
 	char *imsi;
+	guint delayed_set_connected_id;
+	guint delayed_set_connected_attempts;
 };
 
 struct plugin_data {
@@ -593,6 +599,106 @@ static int modem_configure(struct modem_data *md)
 	return index;
 }
 
+static gboolean modem_is_network_configured(struct modem_data *md)
+{
+	DBG("%p", md);
+
+	switch (md->connctx->protocol) {
+	case OFONO_CONNCTX_PROTOCOL_UNKNOWN:
+	case OFONO_CONNCTX_PROTOCOL_NONE:
+		return FALSE;
+
+	case OFONO_CONNCTX_PROTOCOL_IP:
+		if (!connman_network_is_configured(md->network,
+						CONNMAN_IPCONFIG_TYPE_IPV4)) {
+			connman_warn("ofono: %p IPv4 no address set", md);
+			return FALSE;
+		}
+
+		break;
+
+	case OFONO_CONNCTX_PROTOCOL_IPV6:
+		if (!connman_network_is_configured(md->network,
+						CONNMAN_IPCONFIG_TYPE_IPV6)) {
+			connman_warn("ofono: %p IPv6 no address set", md);
+			return FALSE;
+		}
+
+		break;
+
+	case OFONO_CONNCTX_PROTOCOL_DUAL:
+		if (!connman_network_is_configured(md->network,
+						CONNMAN_IPCONFIG_TYPE_IPV4)) {
+			connman_warn("ofono: %p DUAL no IPv4 address set", md);
+			return FALSE;
+		}
+
+		if (!connman_network_is_configured(md->network,
+						CONNMAN_IPCONFIG_TYPE_IPV6)) {
+			connman_warn("ofono: %p DUAL no IPv6 address set", md);
+			return FALSE;
+		}
+
+		break;
+	}
+
+	DBG("%p is configured", md);
+
+	return TRUE;
+}
+
+static gboolean modem_delayed_set_connected(gpointer data)
+{
+	struct modem_data *md = data;
+
+	/* Keep in loop until configured and attempt limit is not reached. */
+	if (!modem_is_network_configured(md) &&
+				md->delayed_set_connected_attempts <
+					DELAYED_CONNECT_LIMIT) {
+		md->delayed_set_connected_attempts++;
+		return G_SOURCE_CONTINUE;
+	}
+
+	/* Log that we're giving up, network setup wasn't completed in time. */
+	if (md->delayed_set_connected_attempts == DELAYED_CONNECT_LIMIT)
+		connman_error("cellular setup was not completed in time");
+
+	DBG("modem %p network %p configured, set connected", md, md->network);
+
+	connman_network_set_connected(md->network, TRUE);
+
+	md->delayed_set_connected_id = 0;
+	md->delayed_set_connected_attempts = 0;
+
+	return G_SOURCE_REMOVE;
+}
+
+static void modem_clean_delayed_set_connected(struct modem_data *md)
+{
+	if (md->delayed_set_connected_id) {
+		g_source_remove(md->delayed_set_connected_id);
+		md->delayed_set_connected_id = 0;
+	}
+
+	md->delayed_set_connected_attempts = 0;
+}
+
+static void modem_set_connected(struct modem_data *md)
+{
+	modem_clean_delayed_set_connected(md);
+
+	if (modem_is_network_configured(md)) {
+		connman_network_set_connected(md->network, TRUE);
+	} else {
+		DBG("%p init delayed connect, modem network not ready", md);
+
+		md->delayed_set_connected_id = g_timeout_add(
+						DELAYED_CONNECT_TIMEOUT_MS,
+						modem_delayed_set_connected,
+						md);
+	}
+}
+
 static void modem_connected(struct modem_data *md)
 {
 	const int index = modem_configure(md);
@@ -602,7 +708,7 @@ static void modem_connected(struct modem_data *md)
 
 	if (index >= 0) {
 		connman_network_set_index(md->network, index);
-		connman_network_set_connected(md->network, TRUE);
+		modem_set_connected(md);
 	}
 }
 
@@ -707,6 +813,7 @@ static void connctx_update_active(struct modem_data *md)
 		} else {
 			connctx_activate_cancel(md);
 			if (md->network) {
+				modem_clean_delayed_set_connected(md);
 				connman_network_set_connected(md->network,
 								FALSE);
 			}
@@ -962,6 +1069,10 @@ static void modem_delete(gpointer value)
 	connctx_activate_cancel(md);
 	if (md->online_check_id) {
 		g_source_remove(md->online_check_id);
+	}
+
+	if (md->delayed_set_connected_id) {
+		g_source_remove(md->delayed_set_connected_id);
 	}
 
 	modem_destroy_device(md);

--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -482,6 +482,7 @@ void __connman_ipconfig_set_prefixlen(struct connman_ipconfig *ipconfig, unsigne
 int __connman_ipconfig_enable(struct connman_ipconfig *ipconfig);
 int __connman_ipconfig_disable(struct connman_ipconfig *ipconfig);
 bool __connman_ipconfig_is_usable(struct connman_ipconfig *ipconfig);
+bool __connman_ipconfig_is_configured(struct connman_ipconfig *ipconfig);
 
 const char *__connman_ipconfig_method2string(enum connman_ipconfig_method method);
 const char *__connman_ipconfig_type2string(enum connman_ipconfig_type type);

--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -184,7 +184,17 @@ void __connman_ipconfig_clear_address(struct connman_ipconfig *ipconfig)
 	if (!ipconfig)
 		return;
 
-	connman_ipaddress_clear(ipconfig->address);
+	switch (ipconfig->method) {
+	case CONNMAN_IPCONFIG_METHOD_UNKNOWN:
+	case CONNMAN_IPCONFIG_METHOD_OFF:
+	case CONNMAN_IPCONFIG_METHOD_AUTO:
+	case CONNMAN_IPCONFIG_METHOD_DHCP:
+		break;
+	case CONNMAN_IPCONFIG_METHOD_FIXED:
+	case CONNMAN_IPCONFIG_METHOD_MANUAL:
+		connman_ipaddress_clear(ipconfig->address);
+		break;
+	}
 }
 
 static void free_address_list(struct connman_ipdevice *ipdevice)

--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -1813,6 +1813,31 @@ bool __connman_ipconfig_is_usable(struct connman_ipconfig *ipconfig)
 	return true;
 }
 
+bool __connman_ipconfig_is_configured(struct connman_ipconfig *ipconfig)
+{
+	if (!ipconfig)
+		return false;
+
+	DBG("%p", ipconfig);
+
+	switch (ipconfig->method) {
+	case CONNMAN_IPCONFIG_METHOD_UNKNOWN:
+	case CONNMAN_IPCONFIG_METHOD_OFF:
+		return false;
+	case CONNMAN_IPCONFIG_METHOD_AUTO:
+	case CONNMAN_IPCONFIG_METHOD_DHCP:
+		break;
+	case CONNMAN_IPCONFIG_METHOD_FIXED:
+	case CONNMAN_IPCONFIG_METHOD_MANUAL:
+		if (!__connman_ipconfig_get_local(ipconfig))
+			return false;
+
+		break;
+	}
+
+	return true;
+}
+
 int __connman_ipconfig_enable(struct connman_ipconfig *ipconfig)
 {
 	struct connman_ipdevice *ipdevice;

--- a/connman/src/network.c
+++ b/connman/src/network.c
@@ -1435,6 +1435,44 @@ bool connman_network_get_associating(struct connman_network *network)
 	return network->associating;
 }
 
+/**
+ * connman_network_is_configured:
+ * @network: network structure
+ * @type: ipconfig type
+ *
+ * Check if the given ipconfig type is configured
+ */
+bool connman_network_is_configured(struct connman_network *network,
+					enum connman_ipconfig_type type)
+{
+	struct connman_service *service;
+	struct connman_ipconfig *ipconfig_ipv4;
+	struct connman_ipconfig *ipconfig_ipv6;
+
+	DBG("%p type %s", network, __connman_ipconfig_type2string(type));
+
+	if (!network)
+		return false;
+
+	service = connman_service_lookup_from_network(network);
+	ipconfig_ipv4 = __connman_service_get_ip4config(service);
+	ipconfig_ipv6 = __connman_service_get_ip6config(service);
+
+	switch (type) {
+	case CONNMAN_IPCONFIG_TYPE_UNKNOWN:
+		return false;
+	case CONNMAN_IPCONFIG_TYPE_IPV4:
+		return __connman_ipconfig_is_configured(ipconfig_ipv4);
+	case CONNMAN_IPCONFIG_TYPE_IPV6:
+		return __connman_ipconfig_is_configured(ipconfig_ipv6);
+	case CONNMAN_IPCONFIG_TYPE_ALL:
+		return __connman_ipconfig_is_configured(ipconfig_ipv4) &&
+				__connman_ipconfig_is_configured(ipconfig_ipv6);
+	}
+
+	return false;
+}
+
 void connman_network_clear_hidden(void *user_data)
 {
 	if (!user_data)

--- a/connman/src/network.c
+++ b/connman/src/network.c
@@ -1774,6 +1774,36 @@ int connman_network_set_ipaddress(struct connman_network *network,
 	return 0;
 }
 
+void connman_network_clear_ipaddress(struct connman_network *network,
+					enum connman_ipconfig_type type)
+{
+	struct connman_service *service;
+	struct connman_ipconfig *ipconfig_ipv4;
+	struct connman_ipconfig *ipconfig_ipv6;
+
+	service = connman_service_lookup_from_network(network);
+	if (!service)
+		return;
+
+	ipconfig_ipv4 = __connman_service_get_ip4config(service);
+	ipconfig_ipv6 = __connman_service_get_ip6config(service);
+
+	switch (type) {
+	case CONNMAN_IPCONFIG_TYPE_UNKNOWN:
+		break;
+	case CONNMAN_IPCONFIG_TYPE_IPV4:
+		__connman_ipconfig_clear_address(ipconfig_ipv4);
+		break;
+	case CONNMAN_IPCONFIG_TYPE_IPV6:
+		__connman_ipconfig_clear_address(ipconfig_ipv6);
+		break;
+	case CONNMAN_IPCONFIG_TYPE_ALL:
+		__connman_ipconfig_clear_address(ipconfig_ipv4);
+		__connman_ipconfig_clear_address(ipconfig_ipv6);
+		break;
+	}
+}
+
 /*
  * Description: Network client requires additional wifi specific info
  */


### PR DESCRIPTION
Might not be the optimal solution but this resolves the issue. By adding an additional check to not to change the ipconfig method unnecessarily and not allowing to update modem ipconfiguration when disconnecting the issue seems to go away. Nevertheless, it was wrong to change ipconfig method from what ofono informed it to be. Utilizing the disconnecting check ensures that settings file is not updated with invalid information.

In addition to this a delayed connect for the cellular is implemented. This will ensure that all IP families do have proper configuration set. The checks apply only to FIXED and MANUAL mode configurations which do need to have local address set by ofono and informed to connmand. Otherwise in some bootup cases there will be two IPv4 addresses for the interface as the old saved IP address etc. are read from settings file as the information about IPv4 network comes late.

It seemed that rtnl.c does get the information beforehand but as ConnMan is built this way it just notifies the system set addresses forward. Messing up with that approach may break more than I'd aim to fix with it. Therefore, ofono should be aware when it can set the network connected. The approach waits for approx. 2 seconds until giving up - i.e., the address information should be arriving within that timeframe and in testing this is done after the first delay, so in error cases the delay in getting mobile data up is 200ms at most, 100ms being average.

Also took some DHCP patches from upstream.