### PR TITLE
Update and fix ConnMan systemd rules

### DIFF
--- a/connman/src/connman.service.in
+++ b/connman/src/connman.service.in
@@ -13,7 +13,7 @@ BusName=net.connman
 Restart=always
 EnvironmentFile=-/etc/sysconfig/connman
 EnvironmentFile=-/var/lib/environment/connman/*.conf
-ExecStart=@sbindir@/connmand -n -W nl80211 --nobacktrace --systemd --noplugin=wifi $SYSCONF_ARGS $CONNMAN_ARGS
+ExecStart=@sbindir@/connmand -n -W nl80211 --nobacktrace --noplugin=wifi $SYSCONF_ARGS $CONNMAN_ARGS
 ExecReload=/usr/bin/dbus-send --system --print-reply --type=method_call --dest=net.connman / net.connman.Firewall.Reload
 StandardOutput=null
 

--- a/connman/src/connman.service.in
+++ b/connman/src/connman.service.in
@@ -1,12 +1,15 @@
 [Unit]
 Description=Connection service
+DefaultDependencies=false
+Conflicts=shutdown.target
 Requires=@CONNMAN_SERVICE_REQUIRES@
 After=@CONNMAN_SERVICE_AFTER@ network-pre.target
-Before=network.target
+Before=network.target multi-user.target shutdown.target
 Wants=network.target
 
 [Service]
-Type=notify
+Type=dbus
+BusName=net.connman
 Restart=always
 EnvironmentFile=-/etc/sysconfig/connman
 EnvironmentFile=-/var/lib/environment/connman/*.conf

--- a/connman/src/main.c
+++ b/connman/src/main.c
@@ -42,9 +42,6 @@
 #include <gweb/gweb.h>
 #include <gweb/gresolv.h>
 #include <gdhcp/gdhcp.h>
-#ifdef SYSTEMD
-#include <systemd/sd-daemon.h>
-#endif
 
 #include "connman.h"
 #include "iptables_ext.h"
@@ -661,9 +658,6 @@ static gchar *option_wifi = NULL;
 static gboolean option_detach = TRUE;
 static gboolean option_dnsproxy = TRUE;
 static gboolean option_backtrace = TRUE;
-#ifdef SYSTEMD
-static gboolean option_systemd = FALSE;
-#endif
 static gboolean option_version = FALSE;
 
 static bool parse_debug(const char *key, const char *value,
@@ -731,10 +725,6 @@ static GOptionEntry options[] = {
 	{ "nobacktrace", 0, G_OPTION_FLAG_REVERSE,
 				G_OPTION_ARG_NONE, &option_backtrace,
 				"Don't print out backtrace information" },
-#ifdef SYSTEMD
-	{ "systemd", 0, 0, G_OPTION_ARG_NONE, &option_systemd,
-				"Notify systemd when started"},
-#endif
 	{ "version", 'v', 0, G_OPTION_ARG_NONE, &option_version,
 				"Show version information and exit" },
 	{ NULL },
@@ -1002,14 +992,6 @@ int main(int argc, char *argv[])
 	g_free(option_plugin);
 	g_free(option_nodevice);
 	g_free(option_noplugin);
-
-#ifdef SYSTEMD
-	/* Tell systemd that we have started up */
-	if( option_systemd ) {
-		DBG("Notifying systemd.");
-		sd_notify(0, "READY=1");
-	}
-#endif
 
 	g_main_loop_run(main_loop);
 

--- a/rpm/connman.spec
+++ b/rpm/connman.spec
@@ -218,8 +218,9 @@ cp -a tools/iptables-unit %{buildroot}%{_libdir}/%{name}/tools
 mkdir -p %{buildroot}%{_sysconfdir}/connman/
 cp -a %{SOURCE1} %{buildroot}%{_sysconfdir}/connman/
 
-mkdir -p %{buildroot}/%{_unitdir}/network.target.wants
-ln -s ../connman.service %{buildroot}/%{_unitdir}/network.target.wants/connman.service
+mkdir -p %{buildroot}/%{_unitdir}/multi-user.target.wants
+ln -s ../connman.service %{buildroot}/%{_unitdir}/multi-user.target.wants/connman.service
+ln -s ../connman-vpn.service %{buildroot}/%{_unitdir}/multi-user.target.wants/connman-vpn.service
 
 mkdir -p %{buildroot}/%{_unitdir}/connman.service.d
 cp -a %{SOURCE2} %{buildroot}/%{_unitdir}/connman.service.d/
@@ -273,7 +274,8 @@ systemctl daemon-reload || :
 %{_prefix}/lib/tmpfiles.d/connman_resolvconf.conf
 %config %{_sysconfdir}/dbus-1/system.d/*.conf
 %{_unitdir}/connman.service
-%{_unitdir}/network.target.wants/connman.service
+%{_unitdir}/multi-user.target.wants/connman.service
+%{_unitdir}/multi-user.target.wants/connman-vpn.service
 %{_unitdir}/connman-vpn.service
 %{_unitdir}/connman.service.d
 /%{_datadir}/dbus-1/system-services/net.connman.vpn.service


### PR DESCRIPTION
Follow [upstream](https://git.kernel.org/pub/scm/network/connman/connman.git/tree/src/connman.service.in) in `connman.service.in`. This changes the type to dbus, which according to `systemd-analyze` cuts the initialization time to ~1/10. Take also other changes upstream has had for systemd for long time.

Remove the symlink from `network.target.wants`. This was wrong as network.target did wait for connmand to complete causing unnecessary delays. This must be done other way around as upstream service file has, and is recommended by [systemd documentation](https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/) and thus, the symlink(s) are moved to `multi-user.target.wants`.