### PR TITLE
Create a new settings file during user storage change process. JB#55593

### DIFF
--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -526,9 +526,10 @@ enum connman_service_type __connman_technology_get_type(
 	return tech->type;
 }
 
-static void connman_technology_save_offlinemode(void)
+static int connman_technology_save_offlinemode(void)
 {
 	GKeyFile *keyfile;
+	int ret;
 
 	keyfile = __connman_storage_load_global();
 	if (!keyfile)
@@ -537,11 +538,11 @@ static void connman_technology_save_offlinemode(void)
 	g_key_file_set_boolean(keyfile, "global",
 					"OfflineMode", global_offlinemode);
 
-	__connman_storage_save_global(keyfile);
+	ret = __connman_storage_save_global(keyfile);
 
 	g_key_file_unref(keyfile);
 
-	return;
+	return ret;
 }
 
 bool connman_technology_load_offlinemode(void)

--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -460,8 +460,11 @@ static int technology_load_values(struct connman_technology *technology,
 	technology->tethering_passphrase = g_key_file_get_string(keyfile,
 				identifier, "Tethering.Passphrase", NULL);
 
-	if (need_saving)
+	if (need_saving) {
+		DBG("technology %p/%s needs saving", technology,
+					get_name(technology->type));
 		technology_save(technology);
+	}
 
 	return 0;
 }

--- a/connman/unit/test-storage.c
+++ b/connman/unit/test-storage.c
@@ -5290,7 +5290,7 @@ static void storage_test_technology_callbacks1()
 
 	/* technology init will create empty settings file */
 	g_assert_true(__connman_technology_disable_all());
-	g_assert_false(__connman_technology_enable_from_config());
+	g_assert_true(__connman_technology_enable_from_config());
 
 	/* Create settings file */
 	settings_file = g_build_filename(STORAGEDIR, "settings", NULL);


### PR DESCRIPTION
User change process does not create initial settings file leading to all technologies disabled unless any technology has its status changed. Make sure the missing file is created whenever a new user is set and its storage directory is changed via __connman_storage_change_user(). 