### PR TITLE
[packaging] Only BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/connman.spec
+++ b/rpm/connman.spec
@@ -46,7 +46,6 @@ BuildRequires:  pkgconfig(libgsupplicant) >= 1.0.17
 BuildRequires:  ppp-devel
 BuildRequires:  libtool
 BuildRequires:  usb-moded-devel >= 0.86.0+mer31
-BuildRequires:  systemd
 BuildRequires:  libglibutil-devel
 BuildRequires:  libdbusaccess-devel
 


### PR DESCRIPTION
We already include systemd as BuildRequires lets drop it so the right systemd
variant gets installed into the builder.