### PR TITLE
CompLZO must always have a value

### DIFF
--- a/connman/vpn/plugins/openvpn.c
+++ b/connman/vpn/plugins/openvpn.c
@@ -79,7 +79,7 @@ struct {
 	{ "OpenVPN.TLSAuthDir", NULL, 1 },
 	{ "OpenVPN.Cipher", "--cipher", 1 },
 	{ "OpenVPN.Auth", "--auth", 1 },
-	{ "OpenVPN.CompLZO", "--comp-lzo", 0 },
+	{ "OpenVPN.CompLZO", "--comp-lzo", 1 },
 	{ "OpenVPN.RemoteCertTls", "--remote-cert-tls", 1 },
 	{ "OpenVPN.ConfigFile", "--config", 1 },
 	{ "OpenVPN.DeviceType", NULL, 1 },


### PR DESCRIPTION
This is a fix to issue of some VPNs not working with the deprecated
--comp-lzo option. In our case CompLZO always has a value or it is
omitted completely as an option.