### PR TITLE
Fix USB ethernet hot-plug

### DIFF
--- a/connman/plugins/ethernet.c
+++ b/connman/plugins/ethernet.c
@@ -73,7 +73,7 @@ static int get_vlan_vid(const char *ifname)
 		return -errno;
 
 	vifr.cmd = GET_VLAN_VID_CMD;
-	stpncpy(vifr.device1, ifname, sizeof(vifr.device1));
+	stpncpy(vifr.device1, ifname, sizeof(vifr.device1) - 1);
 
 	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0)
 		vid = vifr.u.VID;
@@ -99,14 +99,16 @@ static int get_dsa_port(const char *ifname)
 		return -errno;
 
 	memset(&ifr, 0, sizeof(ifr));
-	stpncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+	stpncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name) - 1);
 
 	/* check if it is a vlan and get physical interface name*/
 	vifr.cmd = GET_VLAN_REALDEV_NAME_CMD;
-	stpncpy(vifr.device1, ifname, sizeof(vifr.device1));
+	stpncpy(vifr.device1, ifname, sizeof(vifr.device1) - 1);
 
-	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0)
-		stpncpy(ifr.ifr_name, vifr.u.device2, sizeof(ifr.ifr_name));
+	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0) {
+		stpncpy(ifr.ifr_name, vifr.u.device2, sizeof(ifr.ifr_name) - 1);
+		ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+	}
 
 	/* get driver info */
 	drvinfocmd.cmd =  ETHTOOL_GDRVINFO;

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -9343,8 +9343,19 @@ bool __connman_service_create_from_network(struct connman_network *network)
 	if (__connman_network_get_weakness(network))
 		return true;
 
+	index = connman_network_get_index(network);
+
 	if (service->path) {
 		update_from_network(service, network);
+
+		if (service->ipconfig_ipv4)
+			__connman_ipconfig_set_index(service->ipconfig_ipv4,
+									index);
+
+		if (service->ipconfig_ipv6)
+			__connman_ipconfig_set_index(service->ipconfig_ipv6,
+									index);
+
 		__connman_connection_update_gateway();
 
 		if (service->autoconnect)
@@ -9388,14 +9399,16 @@ bool __connman_service_create_from_network(struct connman_network *network)
 
 	update_from_network(service, network);
 
-	index = connman_network_get_index(network);
-
 	if (!service->ipconfig_ipv4)
 		service->ipconfig_ipv4 = create_ip4config(service, index,
 				CONNMAN_IPCONFIG_METHOD_DHCP);
+	else
+		__connman_ipconfig_set_index(service->ipconfig_ipv4, index);
 
 	if (!service->ipconfig_ipv6)
 		service->ipconfig_ipv6 = create_ip6config(service, index);
+	else
+		__connman_ipconfig_set_index(service->ipconfig_ipv6, index);
 
 	service_register(service);
 	service_schedule_added(service);


### PR DESCRIPTION
This change fixes the re-insertion of a hot-plug USB ethernet. The index of the interface was not updated so after re-insertion the old index was used which resulted in DHCP failing to start. Also included one fix from upstream for ethernet.