### PR TITLE
[ipconfig] Do not enable/disable ipv6 for all ifs. Fixes JB#56478

### DIFF
--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -1736,6 +1736,9 @@ static int disable_ipv6(struct connman_ipconfig *ipconfig)
 
 	ifname = connman_inet_ifname(ipconfig->index);
 
+	if (!ifname)
+		return -ENOENT;
+
 	set_ipv6_state(ifname, false);
 	set_ipv6_autoconf(ifname, false);
 
@@ -1764,6 +1767,9 @@ static int enable_ipv6(struct connman_ipconfig *ipconfig)
 		return -EOPNOTSUPP;
 
 	ifname = connman_inet_ifname(ipconfig->index);
+
+	if (!ifname)
+		return -ENOENT;
 
 	if (ipconfig->method == CONNMAN_IPCONFIG_METHOD_AUTO)
 		set_ipv6_privacy(ifname, ipconfig->ipv6_privacy_config);


### PR DESCRIPTION
This is a patch proposed to upstream. And this is indeed an issue, since the USB device is already removed prior processing this bits in ifconfig.c -> IPv6 gets disabled. This was an unseen and surprising side effect of how USB devices are reacted to.