### PR TITLE
Check for pending requests also on hidden WiFi networks

### DIFF
--- a/connman/include/agent.h
+++ b/connman/include/agent.h
@@ -71,6 +71,7 @@ int connman_agent_queue_message(void *user_context,
 				DBusMessage *msg, int timeout,
 				agent_queue_cb callback, void *user_data,
 				void *agent_data);
+bool connman_agent_queue_search(void *user_context, void *agent_data);
 
 void *connman_agent_get_info(const char *dbus_sender, const char **sender,
 							const char **path);

--- a/connman/src/agent-connman.c
+++ b/connman/src/agent-connman.c
@@ -856,3 +856,19 @@ int __connman_agent_request_peer_authorization(struct connman_peer *peer,
 
 	return -EINPROGRESS;
 }
+
+bool __connman_agent_is_request_pending(struct connman_service *service,
+						const char *dbus_sender)
+{
+	void *agent;
+
+	/* Default agent will be returned if no dbus_sender */
+	agent = connman_agent_get_info(dbus_sender, NULL, NULL);
+
+	DBG("agent %p service %p", agent, service);
+
+	if (!service || !agent)
+		return false;
+
+	return connman_agent_queue_search(service, agent);
+}

--- a/connman/src/agent.c
+++ b/connman/src/agent.c
@@ -257,6 +257,34 @@ int connman_agent_queue_message(void *user_context,
 	return err;
 }
 
+bool connman_agent_queue_search(void *user_context, void *agent_data)
+{
+	struct connman_agent *agent = agent_data;
+	struct connman_agent_request *queue_data;
+	GList *iter;
+
+	DBG("user context %p agent %p", user_context, agent);
+
+	if (!agent || !user_context)
+		return false;
+
+	if (agent->pending && agent->pending->user_context == user_context) {
+		DBG("user context %p is pending for reply", user_context);
+		return true;
+	}
+
+	for (iter = agent->queue; iter; iter = iter->next) {
+		queue_data = iter->data;
+
+		if (queue_data && queue_data->user_context == user_context) {
+			DBG("user context %p is in queue", user_context);
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static void set_default_agent(void)
 {
 	struct connman_agent *agent = NULL;

--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -128,6 +128,8 @@ int __connman_agent_request_peer_authorization(struct connman_peer *peer,
 						bool wps_requested,
 						const char *dbus_sender,
 						void *user_data);
+bool __connman_agent_is_request_pending(struct connman_service *service,
+						const char *dbus_sender);
 
 #include <connman/log.h>
 

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -5800,7 +5800,10 @@ static DBusMessage *connect_service(DBusConnection *conn,
 				service->type == CONNMAN_SERVICE_TYPE_VPN))
 		return __connman_error_no_carrier(msg);
 
-	if (service->pending)
+	/* Hidden services do not keep the pending msg, check it from agent */
+	if (service->pending || (service->hidden &&
+				__connman_agent_is_request_pending(service,
+						dbus_message_get_sender(msg))))
 		return __connman_error_in_progress(msg);
 
 	index = __connman_service_get_index(service);


### PR DESCRIPTION
Hidden services do not keep the pending call when connecting as that is
forwarded for agent to handle, if present. This patch set adds simple search
to agent.c that can be used in service.c via agent-connman.c to check if the
hidden service has a pending connect request.

It was noticed that two consecutive connect requests for a hidden service was
possible and this resulted in adding two separate requests when agent was
present. First requests was placed as the pending request on the agent and the
second one was allowed as well but it was put into the queue. And when time-out
happened on the first one then the duplicate request would have been sent.

UI components relying on D-Bus API should not have to deal with this, it is
better to handle this case on ConnMan side.