### PR TITLE
[connman] Apply upstream rtnl patches, revert debug disable commit. JB#57933

### DIFF
--- a/connman/src/detect.c
+++ b/connman/src/detect.c
@@ -49,7 +49,7 @@ static void detect_newlink(unsigned short type, int index,
 	struct connman_device *device;
 	enum connman_device_type devtype;
 
-//	DBG("type %d index %d", type, index);
+	DBG("type %d index %d", type, index);
 
 	devtype = __connman_rtnl_get_device_type(index);
 

--- a/connman/src/device.c
+++ b/connman/src/device.c
@@ -1316,7 +1316,7 @@ struct connman_device *connman_device_create_from_index(int index)
 		return NULL;
 
 	if (__connman_device_isfiltered(devname)) {
-//		DBG("Ignoring interface %s (filtered)", devname);
+		DBG("Ignoring interface %s (filtered)", devname);
 		g_free(devname);
 		return NULL;
 	}
@@ -1325,7 +1325,7 @@ struct connman_device *connman_device_create_from_index(int index)
 
 	switch (type) {
 	case CONNMAN_DEVICE_TYPE_UNKNOWN:
-//		DBG("Ignoring interface %s (type unknown)", devname);
+		DBG("Ignoring interface %s (type unknown)", devname);
 		g_free(devname);
 		return NULL;
 	case CONNMAN_DEVICE_TYPE_ETHERNET:
@@ -1400,13 +1400,13 @@ bool __connman_device_isfiltered(const char *devname)
 	}
 
 	if (!match) {
-//		DBG("ignoring device %s (match)", devname);
+		DBG("ignoring device %s (match)", devname);
 		return true;
 	}
 
 nodevice:
 	if (g_pattern_match_simple("dummy*", devname)) {
-//		DBG("ignoring dummy networking devices");
+		DBG("ignoring dummy networking devices");
 		return true;
 	}
 
@@ -1415,7 +1415,7 @@ nodevice:
 
 	for (pattern = nodevice_filter; *pattern; pattern++) {
 		if (g_pattern_match_simple(*pattern, devname)) {
-//			DBG("ignoring device %s (no match)", devname);
+			DBG("ignoring device %s (no match)", devname);
 			return true;
 		}
 	}
@@ -1428,7 +1428,7 @@ list:
 
 	for (pattern = blacklisted_interfaces; *pattern; pattern++) {
 		if (g_str_has_prefix(devname, *pattern)) {
-//			DBG("ignoring device %s (blacklist)", devname);
+			DBG("ignoring device %s (blacklist)", devname);
 			return true;
 		}
 	}
@@ -1459,8 +1459,7 @@ static void cleanup_devices(void)
 	/*
 	 * Check what interfaces are currently up and if connman is
 	 * suppose to handle the interface, then cleanup the mess
-
-         * related to that interface. There might be weird routes etc
+	 * related to that interface. There might be weird routes etc
 	 * that are related to that interface and that might confuse
 	 * connmand. So in this case we just turn the interface down
 	 * so that kernel removes routes/addresses automatically and

--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -574,10 +574,10 @@ static void update_stats(struct connman_ipdevice *ipdevice,
 	if (stats->rx_packets == 0 && stats->tx_packets == 0)
 		return;
 
-//	DBG("%s {RX} %llu packets %llu bytes", ifname,
-//					stats->rx_packets, stats->rx_bytes);
-//	DBG("%s {TX} %llu packets %llu bytes", ifname,
-//					stats->tx_packets, stats->tx_bytes);
+	DBG("%s {RX} %llu packets %llu bytes", ifname,
+					stats->rx_packets, stats->rx_bytes);
+	DBG("%s {TX} %llu packets %llu bytes", ifname,
+					stats->tx_packets, stats->tx_bytes);
 
 	if (!ipdevice->config_ipv4 && !ipdevice->config_ipv6)
 		return;
@@ -632,7 +632,7 @@ void __connman_ipconfig_newlink(int index, unsigned short type,
 	bool lower_up = false, lower_down = false;
 	char *ifname;
 
-//	DBG("index %d", index);
+	DBG("index %d", index);
 
 	if (type == ARPHRD_LOOPBACK)
 		return;
@@ -2082,7 +2082,7 @@ void __connman_ipconfig_append_ipv4(struct connman_ipconfig *ipconfig,
 	struct connman_ipaddress *append_addr = NULL;
 	const char *str;
 
-//	DBG("");
+	DBG("");
 
 	if (ipconfig->type != CONNMAN_IPCONFIG_TYPE_IPV4)
 		return;
@@ -2139,7 +2139,7 @@ void __connman_ipconfig_append_ipv6(struct connman_ipconfig *ipconfig,
 	struct connman_ipaddress *append_addr = NULL;
 	const char *str, *privacy;
 
-//	DBG("");
+	DBG("");
 
 	if (ipconfig->type != CONNMAN_IPCONFIG_TYPE_IPV6)
 		return;
@@ -2197,7 +2197,7 @@ void __connman_ipconfig_append_ipv6config(struct connman_ipconfig *ipconfig,
 {
 	const char *str, *privacy;
 
-//	DBG("");
+	DBG("");
 
 	str = __connman_ipconfig_method2string(ipconfig->method);
 	if (!str)
@@ -2241,7 +2241,7 @@ void __connman_ipconfig_append_ipv4config(struct connman_ipconfig *ipconfig,
 {
 	const char *str;
 
-//	DBG("");
+	DBG("");
 
 	str = __connman_ipconfig_method2string(ipconfig->method);
 	if (!str)

--- a/connman/src/network.c
+++ b/connman/src/network.c
@@ -1891,7 +1891,7 @@ int connman_network_set_nameservers(struct connman_network *network,
 	char **nameservers_array;
 	int i;
 
-//	DBG("network %p nameservers %s", network, nameservers);
+	DBG("network %p nameservers %s", network, nameservers);
 
 	service = connman_service_lookup_from_network(network);
 	if (!service)
@@ -1940,7 +1940,7 @@ int connman_network_set_domain(struct connman_network *network,
 int connman_network_set_name(struct connman_network *network,
 							const char *name)
 {
-//	DBG("network %p name %s", network, name);
+	DBG("network %p name %s", network, name);
 
 	g_free(network->name);
 	network->name = g_strdup(name);
@@ -1998,7 +1998,7 @@ uint16_t connman_network_get_frequency(struct connman_network *network)
 int connman_network_set_wifi_channel(struct connman_network *network,
 						uint16_t channel)
 {
-//	DBG("network %p wifi channel %d", network, channel);
+	DBG("network %p wifi channel %d", network, channel);
 
 	network->wifi.channel = channel;
 
@@ -2021,7 +2021,7 @@ uint16_t connman_network_get_wifi_channel(struct connman_network *network)
 int connman_network_set_string(struct connman_network *network,
 					const char *key, const char *value)
 {
-//	DBG("network %p key %s value %s", network, key, value);
+	DBG("network %p key %s value %s", network, key, value);
 
 	if (g_strcmp0(key, "Name") == 0)
 		return connman_network_set_name(network, value);
@@ -2109,7 +2109,7 @@ int connman_network_set_string(struct connman_network *network,
 const char *connman_network_get_string(struct connman_network *network,
 							const char *key)
 {
-//	DBG("network %p key %s", network, key);
+	DBG("network %p key %s", network, key);
 
 	if (g_str_equal(key, "Path"))
 		return network->path;
@@ -2172,7 +2172,7 @@ const char *connman_network_get_string(struct connman_network *network,
 int connman_network_set_bool(struct connman_network *network,
 					const char *key, bool value)
 {
-//	DBG("network %p key %s value %d", network, key, value);
+	DBG("network %p key %s value %d", network, key, value);
 
 	if (g_strcmp0(key, "Roaming") == 0)
 		network->roaming = value;
@@ -2194,7 +2194,7 @@ int connman_network_set_bool(struct connman_network *network,
 bool connman_network_get_bool(struct connman_network *network,
 							const char *key)
 {
-//	DBG("network %p key %s", network, key);
+	DBG("network %p key %s", network, key);
 
 	if (g_str_equal(key, "Roaming"))
 		return network->roaming;
@@ -2218,7 +2218,7 @@ bool connman_network_get_bool(struct connman_network *network,
 int connman_network_set_blob(struct connman_network *network,
 			const char *key, const void *data, unsigned int size)
 {
-//	DBG("network %p key %s size %d", network, key, size);
+	DBG("network %p key %s size %d", network, key, size);
 
 	if (g_str_equal(key, "WiFi.SSID")) {
 		g_free(network->wifi.ssid);
@@ -2246,7 +2246,7 @@ int connman_network_set_blob(struct connman_network *network,
 const void *connman_network_get_blob(struct connman_network *network,
 					const char *key, unsigned int *size)
 {
-//	DBG("network %p key %s", network, key);
+	DBG("network %p key %s", network, key);
 
 	if (g_str_equal(key, "WiFi.SSID")) {
 		if (size)

--- a/connman/src/ntp.c
+++ b/connman/src/ntp.c
@@ -144,7 +144,7 @@ static gboolean send_timeout(gpointer user_data)
 {
 	uint32_t timeout = GPOINTER_TO_UINT(user_data);
 
-//	DBG("send timeout %u (retries %d)", timeout, retries);
+	DBG("send timeout %u (retries %d)", timeout, retries);
 
 	if (retries++ == NTP_SEND_RETRIES)
 		next_server();

--- a/connman/src/rtnl.c
+++ b/connman/src/rtnl.c
@@ -1331,75 +1331,71 @@ static const char *type2string(uint16_t type)
 static GIOChannel *channel = NULL;
 static guint channel_watch = 0;
 
-struct rtnl_request {
-	struct nlmsghdr hdr;
-	struct rtgenmsg msg;
-};
-#define RTNL_REQUEST_SIZE  (sizeof(struct nlmsghdr) + sizeof(struct rtgenmsg))
+#define RTNL_REQUEST_SIZE (NLMSG_HDRLEN + NLMSG_ALIGN(sizeof(struct rtgenmsg)))
 
 static GSList *request_list = NULL;
 static guint32 request_seq = 0;
 
-static struct rtnl_request *find_request(guint32 seq)
+static struct nlmsghdr *find_request(guint32 seq)
 {
 	GSList *list;
 
 	for (list = request_list; list; list = list->next) {
-		struct rtnl_request *req = list->data;
+		struct nlmsghdr *hdr = list->data;
 
-		if (req->hdr.nlmsg_seq == seq)
-			return req;
+		if (hdr->nlmsg_seq == seq)
+			return hdr;
 	}
 
 	return NULL;
 }
 
-static int send_request(struct rtnl_request *req)
+static int send_request(struct nlmsghdr *hdr)
 {
 	struct sockaddr_nl addr;
 	int sk;
 
 	DBG("%s len %d type %d flags 0x%04x seq %d",
-				type2string(req->hdr.nlmsg_type),
-				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
-				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
+				type2string(hdr->nlmsg_type),
+				hdr->nlmsg_len, hdr->nlmsg_type,
+				hdr->nlmsg_flags, hdr->nlmsg_seq);
 
 	sk = g_io_channel_unix_get_fd(channel);
 
 	memset(&addr, 0, sizeof(addr));
 	addr.nl_family = AF_NETLINK;
 
-	return sendto(sk, req, req->hdr.nlmsg_len, 0,
+	return sendto(sk, hdr, hdr->nlmsg_len, 0,
 				(struct sockaddr *) &addr, sizeof(addr));
 }
 
-static int queue_request(struct rtnl_request *req)
+static int queue_request(struct nlmsghdr *hdr)
 {
-	request_list = g_slist_append(request_list, req);
+	request_list = g_slist_append(request_list, hdr);
 
 	if (g_slist_length(request_list) > 1)
 		return 0;
 
-	return send_request(req);
+	return send_request(hdr);
 }
 
 static int process_response(guint32 seq)
 {
-	struct rtnl_request *req;
+	struct nlmsghdr *hdr;
 
 	DBG("seq %d", seq);
 
-	req = find_request(seq);
-	if (req) {
-		request_list = g_slist_remove(request_list, req);
-		g_free(req);
+	hdr = find_request(seq);
+	if (hdr) {
+		request_list = g_slist_remove(request_list, hdr);
+		g_free(hdr);
 	}
 
-	req = g_slist_nth_data(request_list, 0);
-	if (!req)
+	hdr = g_slist_nth_data(request_list, 0);
+	if (!hdr)
 		return 0;
 
-	return send_request(req);
+	return send_request(hdr);
 }
 
 static void rtnl_message(void *buf, size_t len)
@@ -1499,62 +1495,65 @@ static gboolean netlink_event(GIOChannel *chan, GIOCondition cond, gpointer data
 
 static int send_getlink(void)
 {
-	struct rtnl_request *req;
+	struct nlmsghdr *hdr;
+	struct rtgenmsg *msg;
 
 	DBG("");
 
-	req = g_try_malloc0(RTNL_REQUEST_SIZE);
-	if (!req)
-		return -ENOMEM;
+	hdr = g_malloc0(RTNL_REQUEST_SIZE);
 
-	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
-	req->hdr.nlmsg_type = RTM_GETLINK;
-	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
-	req->hdr.nlmsg_pid = 0;
-	req->hdr.nlmsg_seq = request_seq++;
-	req->msg.rtgen_family = AF_INET;
+	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
+	hdr->nlmsg_type = RTM_GETLINK;
+	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+	hdr->nlmsg_pid = 0;
+	hdr->nlmsg_seq = request_seq++;
 
-	return queue_request(req);
+	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
+	msg->rtgen_family = AF_INET;
+
+	return queue_request(hdr);
 }
 
 static int send_getaddr(void)
 {
-	struct rtnl_request *req;
+	struct nlmsghdr *hdr;
+	struct rtgenmsg *msg;
 
 	DBG("");
 
-	req = g_try_malloc0(RTNL_REQUEST_SIZE);
-	if (!req)
-		return -ENOMEM;
+	hdr = g_malloc0(RTNL_REQUEST_SIZE);
 
-	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
-	req->hdr.nlmsg_type = RTM_GETADDR;
-	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
-	req->hdr.nlmsg_pid = 0;
-	req->hdr.nlmsg_seq = request_seq++;
-	req->msg.rtgen_family = AF_INET;
+	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
+	hdr->nlmsg_type = RTM_GETADDR;
+	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+	hdr->nlmsg_pid = 0;
+	hdr->nlmsg_seq = request_seq++;
 
-	return queue_request(req);
+	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
+	msg->rtgen_family = AF_INET;
+
+	return queue_request(hdr);
 }
 
 static int send_getroute(void)
 {
-	struct rtnl_request *req;
+	struct nlmsghdr *hdr;
+	struct rtgenmsg *msg;
 
 	DBG("");
 
-	req = g_try_malloc0(RTNL_REQUEST_SIZE);
-	if (!req)
-		return -ENOMEM;
+	hdr = g_malloc0(RTNL_REQUEST_SIZE);
 
-	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
-	req->hdr.nlmsg_type = RTM_GETROUTE;
-	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
-	req->hdr.nlmsg_pid = 0;
-	req->hdr.nlmsg_seq = request_seq++;
-	req->msg.rtgen_family = AF_INET;
+	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
+	hdr->nlmsg_type = RTM_GETROUTE;
+	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+	hdr->nlmsg_pid = 0;
+	hdr->nlmsg_seq = request_seq++;
 
-	return queue_request(req);
+	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
+	msg->rtgen_family = AF_INET;
+
+	return queue_request(hdr);
 }
 
 static gboolean update_timeout_cb(gpointer user_data)
@@ -1698,14 +1697,14 @@ void __connman_rtnl_cleanup(void)
 	update_list = NULL;
 
 	for (list = request_list; list; list = list->next) {
-		struct rtnl_request *req = list->data;
+		struct nlmsghdr *hdr= list->data;
 
 		DBG("%s len %d type %d flags 0x%04x seq %d",
-				type2string(req->hdr.nlmsg_type),
-				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
-				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
+				type2string(hdr->nlmsg_type),
+				hdr->nlmsg_len, hdr->nlmsg_type,
+				hdr->nlmsg_flags, hdr->nlmsg_seq);
 
-		g_free(req);
+		g_free(hdr);
 		list->data = NULL;
 	}
 

--- a/connman/src/rtnl.c
+++ b/connman/src/rtnl.c
@@ -457,8 +457,8 @@ static void process_newlink(unsigned short type, int index, unsigned flags,
 						address.ether_addr_octet[5]);
 
 	if (flags & IFF_SLAVE) {
-	//	DBG("%s {newlink} ignoring slave, index %d address %s",
-	//					ifname, index, str);
+		DBG("%s {newlink} ignoring slave, index %d address %s",
+						ifname, index, str);
 		return;
 	}
 
@@ -475,13 +475,13 @@ static void process_newlink(unsigned short type, int index, unsigned flags,
 		break;
 	}
 
-//        DBG("%s {newlink} index %d address %s mtu %u",
-//						ifname, index, str, mtu);
+        DBG("%s {newlink} index %d address %s mtu %u",
+						ifname, index, str, mtu);
 
-//	if (operstate != 0xff)
-//		DBG("%s {newlink} index %d operstate %u <%s>",
-//						ifname, index, operstate,
-//						operstate2str(operstate));
+	if (operstate != 0xff)
+		DBG("%s {newlink} index %d operstate %u <%s>",
+						ifname, index, operstate,
+						operstate2str(operstate));
 
 	interface = g_hash_table_lookup(interface_list, GINT_TO_POINTER(index));
 	if (!interface) {
@@ -1353,10 +1353,10 @@ static int send_request(struct rtnl_request *req)
 	struct sockaddr_nl addr;
 	int sk;
 
-//	DBG("%s len %d type %d flags 0x%04x seq %d",
-//				type2string(req->hdr.nlmsg_type),
-//				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
-//				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
+	DBG("%s len %d type %d flags 0x%04x seq %d",
+				type2string(req->hdr.nlmsg_type),
+				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
+				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
 
 	sk = g_io_channel_unix_get_fd(channel);
 
@@ -1381,7 +1381,7 @@ static int process_response(guint32 seq)
 {
 	struct rtnl_request *req;
 
-//	DBG("seq %d", seq);
+	DBG("seq %d", seq);
 
 	req = find_request(seq);
 	if (req) {
@@ -1398,7 +1398,7 @@ static int process_response(guint32 seq)
 
 static void rtnl_message(void *buf, size_t len)
 {
-//	DBG("buf %p len %zd", buf, len);
+	DBG("buf %p len %zd", buf, len);
 
 	while (len > 0) {
 		struct nlmsghdr *hdr = buf;
@@ -1407,11 +1407,11 @@ static void rtnl_message(void *buf, size_t len)
 		if (!NLMSG_OK(hdr, len))
 			break;
 
-//		DBG("%s len %d type %d flags 0x%04x seq %d pid %d",
-//					type2string(hdr->nlmsg_type),
-//					hdr->nlmsg_len, hdr->nlmsg_type,
-//					hdr->nlmsg_flags, hdr->nlmsg_seq,
-//					hdr->nlmsg_pid);
+		DBG("%s len %d type %d flags 0x%04x seq %d pid %d",
+					type2string(hdr->nlmsg_type),
+					hdr->nlmsg_len, hdr->nlmsg_type,
+					hdr->nlmsg_flags, hdr->nlmsg_seq,
+					hdr->nlmsg_pid);
 
 		switch (hdr->nlmsg_type) {
 		case NLMSG_NOOP:
@@ -1495,7 +1495,7 @@ static int send_getlink(void)
 {
 	struct rtnl_request *req;
 
-//	DBG("");
+	DBG("");
 
 	req = g_try_malloc0(RTNL_REQUEST_SIZE);
 	if (!req)

--- a/connman/src/rtnl.c
+++ b/connman/src/rtnl.c
@@ -198,6 +198,9 @@ static void read_uevent(struct interface_data *interface)
 		} else if (strcmp(devtype + 8, "bond") == 0) {
 			interface->service_type = CONNMAN_SERVICE_TYPE_ETHERNET;
 			interface->device_type = CONNMAN_DEVICE_TYPE_ETHERNET;
+		} else if (strcmp(devtype + 8, "dsa") == 0) {
+			interface->service_type = CONNMAN_SERVICE_TYPE_ETHERNET;
+			interface->device_type = CONNMAN_DEVICE_TYPE_ETHERNET;
 		} else {
 			connman_warn("%s DEVTYPE=%s not supported, ignoring",
 					name, devtype);

--- a/connman/src/rtnl.c
+++ b/connman/src/rtnl.c
@@ -195,6 +195,9 @@ static void read_uevent(struct interface_data *interface)
 		} else if (strcmp(devtype, "vlan") == 0) {
 			interface->service_type = CONNMAN_SERVICE_TYPE_ETHERNET;
 			interface->device_type = CONNMAN_DEVICE_TYPE_ETHERNET;
+		} else if (strcmp(devtype + 8, "bond") == 0) {
+			interface->service_type = CONNMAN_SERVICE_TYPE_ETHERNET;
+			interface->device_type = CONNMAN_DEVICE_TYPE_ETHERNET;
 		} else {
 			connman_warn("%s DEVTYPE=%s not supported, ignoring",
 					name, devtype);


### PR DESCRIPTION
Applied a patch that fixes the alignment of netlink messages. And also couple of others non-related to maintain consistency in rtnl.c.

Reverted old debug disable commit that was not just proper. `DBG()`s are handled via bootup option or D-Bus toggle with dbuslog-tools. 