### PR TITLE
gdbus: Make dbus calls in g_dbus_proxy_set_property_* methods blocking

### DIFF
--- a/connman/gdbus/client.c
+++ b/connman/gdbus/client.c
@@ -3,7 +3,7 @@
  *  D-Bus helper library
  *
  *  Copyright (C) 2004-2011  Marcel Holtmann <marcel@holtmann.org>
- *
+ *  Copyright (C) 2022 Open Mobile Platform LLC.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -722,6 +722,7 @@ gboolean g_dbus_proxy_set_property_basic(GDBusProxy *proxy,
 	}
 
 	dbus_pending_call_set_notify(call, set_property_reply, data, g_free);
+	dbus_pending_call_block(call);
 	dbus_pending_call_unref(call);
 
 	dbus_message_unref(msg);
@@ -809,6 +810,7 @@ gboolean g_dbus_proxy_set_property_array(GDBusProxy *proxy,
 	}
 
 	dbus_pending_call_set_notify(call, set_property_reply, data, g_free);
+	dbus_pending_call_block(call);
 	dbus_pending_call_unref(call);
 
 	dbus_message_unref(msg);


### PR DESCRIPTION
Due to non-blocking dbus calls, these methods become thread-unsafe
and may lead to race conditions in callback threads.

The problem was detected while working with bluetooth plugin: at the moment of powering off bluetooth, function _g_dbus_proxy_set_property_basic_ is called several times (change properties Powered and Discoverable to false). Due to some reason changing property Power was not in time at the moment of starting changing property Discoverable, which led to problems with powering off adapter. By making dbus calls blocking, we can guarantee that execution order of callbacks will not be corrupted. 