### PR TITLE
Revert "[wifi] Implement a heurestic for determening a weak WiFi."

### DIFF
--- a/connman/plugins/sailfish_wifi.c
+++ b/connman/plugins/sailfish_wifi.c
@@ -65,11 +65,7 @@
 #define WIFI_BSS_COUNT_SMALL (10)
 #define WIFI_BSS_COUNT_MAX (100)
 #define WIFI_WEAK_RSSI (-85) /* dBm */
-#define WIFI_WEAK_RSSI_MAX (-65) /* dBm */
 #define WIFI_WEAK_BSS_MIN_SIGHTINGS (3)
-
-#define WIFI_SERVICE_COUNT_INTERVAL (20)
-#define WIFI_RSSI_INCREASE_INTERVAL (5)
 
 /* Access point (tethering) configuration */
 #define WIFI_AP_FREQUENCY (2412)
@@ -642,23 +638,7 @@ static void wifi_bss_free(struct wifi_bss *bss_data)
 
 static inline gboolean wifi_bss_weak(const struct wifi_bss *bss_data)
 {
-	int weak_rssi = WIFI_WEAK_RSSI;
-	int services;
-
-	services = connman_service_get_available_count(
-						CONNMAN_SERVICE_TYPE_WIFI);
-	if (services) {
-		int multiplier = services / WIFI_SERVICE_COUNT_INTERVAL;
-		weak_rssi += WIFI_RSSI_INCREASE_INTERVAL * multiplier;
-
-		/* Keep at same level as background scan. */
-		if (weak_rssi > WIFI_WEAK_RSSI_MAX)
-			weak_rssi = WIFI_WEAK_RSSI_MAX;
-	}
-
-	DBG("WEAK_RSSI %d, %d services", weak_rssi, services);
-
-	return (bss_data->signal < weak_rssi);
+	return (bss_data->signal < WIFI_WEAK_RSSI);
 }
 
 static inline gboolean wifi_bss_ignorable(const struct wifi_bss *bss_data)


### PR DESCRIPTION
This heuristic causes errors with eap wifi networks in areas with many wifi networks. 
It seems that heuristic drops performance because of frequent calls of wifi_bss_weak function.
This reverts commit e7b19da35f5de5b3d6a88b7dfe85a96397d0c95a.