### PR TITLE
[connman] Address CVE-2022-32293. Fixes JB#59298

### DIFF
--- a/connman/gweb/gweb.c
+++ b/connman/gweb/gweb.c
@@ -935,7 +935,7 @@ static gboolean received_data(GIOChannel *channel, GIOCondition cond,
 		}
 
 		*pos = '\0';
-		count = strlen((char *) ptr);
+		count = pos - ptr;
 		if (count > 0 && ptr[count - 1] == '\r') {
 			ptr[--count] = '\0';
 			bytes_read--;

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -1048,17 +1048,11 @@ void __connman_wispr_stop(struct connman_service *service)
 	if (!wispr_portal)
 		return;
 
-	if (wispr_portal->ipv4_context) {
-		if (service == wispr_portal->ipv4_context->service)
-			g_hash_table_remove(wispr_portal_list,
-					GINT_TO_POINTER(index));
-	}
-
-	if (wispr_portal->ipv6_context) {
-		if (service == wispr_portal->ipv6_context->service)
-			g_hash_table_remove(wispr_portal_list,
-					GINT_TO_POINTER(index));
-	}
+	if ((wispr_portal->ipv4_context &&
+	     service == wispr_portal->ipv4_context->service) ||
+	    (wispr_portal->ipv6_context &&
+	     service == wispr_portal->ipv6_context->service))
+		g_hash_table_remove(wispr_portal_list, GINT_TO_POINTER(index));
 }
 
 int __connman_wispr_init(void)

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -839,7 +839,7 @@ static void proxy_callback(const char *proxy, void *user_data)
 
 	DBG("proxy %s", proxy);
 
-	if (!wp_context)
+	if (!wp_context || !proxy)
 		return;
 
 	wp_context->token = 0;

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -549,7 +549,8 @@ static bool wispr_route_request(const char *address, int ai_family,
 static void wispr_portal_request_portal(
 		struct connman_wispr_portal_context *wp_context)
 {
-	DBG("");
+	DBG("wp_context %p %s", wp_context,
+		__connman_ipconfig_type2string(wp_context->type));
 
 	wispr_portal_context_ref(wp_context);
 	wp_context->request_id = g_web_request_get(wp_context->web,
@@ -773,7 +774,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 		if (length > 0) {
 			g_web_parser_feed_data(wp_context->wispr_parser,
 								chunk, length);
-			wispr_portal_context_unref(wp_context);
+			/* read more data */
 			return true;
 		}
 
@@ -808,8 +809,6 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 			// Cancel browser requests if useragent has not returned anything
 			connman_agent_cancel(wp_context->service);
 			portal_manage_status(result, wp_context);
-			wispr_portal_context_unref(wp_context);
-			return false;
 		} else {
 			wispr_portal_context_ref(wp_context);
 			__connman_agent_request_browser(wp_context->service,
@@ -1010,7 +1009,8 @@ int __connman_wispr_start(struct connman_service *service,
 	struct connman_wispr_portal *wispr_portal = NULL;
 	int index, err;
 
-	DBG("service %p", service);
+	DBG("service %p %s", service,
+		__connman_ipconfig_type2string(type));
 
 	if (!wispr_portal_hash)
 		return -EINVAL;

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -57,6 +57,7 @@ struct wispr_route {
 };
 
 struct connman_wispr_portal_context {
+	int refcount;
 	struct connman_service *service;
 	enum connman_ipconfig_type type;
 	struct connman_wispr_portal *wispr_portal;
@@ -93,6 +94,11 @@ struct connman_wispr_portal {
 static bool wispr_portal_web_result(GWebResult *result, gpointer user_data);
 
 static GHashTable *wispr_portal_hash = NULL;
+
+#define wispr_portal_context_ref(wp_context) \
+	wispr_portal_context_ref_debug(wp_context, __FILE__, __LINE__, __func__)
+#define wispr_portal_context_unref(wp_context) \
+	wispr_portal_context_unref_debug(wp_context, __FILE__, __LINE__, __func__)
 
 static void connman_wispr_message_init(struct connman_wispr_message *msg)
 {
@@ -162,9 +168,6 @@ static void free_connman_wispr_portal_context(
 {
 	DBG("context %p", wp_context);
 
-	if (!wp_context)
-		return;
-
 	if (wp_context->wispr_portal) {
 		if (wp_context->wispr_portal->ipv4_context == wp_context)
 			wp_context->wispr_portal->ipv4_context = NULL;
@@ -203,9 +206,38 @@ static void free_connman_wispr_portal_context(
 	g_free(wp_context);
 }
 
+static struct connman_wispr_portal_context *
+wispr_portal_context_ref_debug(struct connman_wispr_portal_context *wp_context,
+			const char *file, int line, const char *caller)
+{
+	DBG("%p ref %d by %s:%d:%s()", wp_context,
+		wp_context->refcount + 1, file, line, caller);
+
+	__sync_fetch_and_add(&wp_context->refcount, 1);
+
+	return wp_context;
+}
+
+static void wispr_portal_context_unref_debug(
+		struct connman_wispr_portal_context *wp_context,
+		const char *file, int line, const char *caller)
+{
+	if (!wp_context)
+		return;
+
+	DBG("%p ref %d by %s:%d:%s()", wp_context,
+		wp_context->refcount - 1, file, line, caller);
+
+	if (__sync_fetch_and_sub(&wp_context->refcount, 1) != 1)
+		return;
+
+	free_connman_wispr_portal_context(wp_context);
+}
+
 static struct connman_wispr_portal_context *create_wispr_portal_context(void)
 {
-	return g_try_new0(struct connman_wispr_portal_context, 1);
+	return wispr_portal_context_ref(
+		g_new0(struct connman_wispr_portal_context, 1));
 }
 
 static void free_connman_wispr_portal(gpointer data)
@@ -217,8 +249,8 @@ static void free_connman_wispr_portal(gpointer data)
 	if (!wispr_portal)
 		return;
 
-	free_connman_wispr_portal_context(wispr_portal->ipv4_context);
-	free_connman_wispr_portal_context(wispr_portal->ipv6_context);
+	wispr_portal_context_unref(wispr_portal->ipv4_context);
+	wispr_portal_context_unref(wispr_portal->ipv6_context);
 
 	g_free(wispr_portal);
 }
@@ -627,7 +659,7 @@ static void wispr_portal_request_wispr_login(struct connman_service *service,
 				return;
 		}
 
-		free_connman_wispr_portal_context(wp_context);
+		wispr_portal_context_unref(wp_context);
 		return;
 	}
 
@@ -959,7 +991,7 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
 
 		if (wp_context->token == 0) {
 			err = -EINVAL;
-			free_connman_wispr_portal_context(wp_context);
+			wispr_portal_context_unref(wp_context);
 		}
 	} else if (wp_context->timeout == 0) {
 		wp_context->timeout =
@@ -1009,7 +1041,7 @@ int __connman_wispr_start(struct connman_service *service,
 
 	/* If there is already an existing context, we wipe it */
 	if (wp_context)
-		free_connman_wispr_portal_context(wp_context);
+		wispr_portal_context_unref(wp_context);
 
 	wp_context = create_wispr_portal_context();
 	if (!wp_context)

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -1029,6 +1029,7 @@ int __connman_wispr_start(struct connman_service *service,
 
 void __connman_wispr_stop(struct connman_service *service)
 {
+	struct connman_wispr_portal *wispr_portal;
 	int index;
 
 	DBG("service %p", service);
@@ -1041,7 +1042,23 @@ void __connman_wispr_stop(struct connman_service *service)
 		return;
 
 	connman_agent_cancel(service);
-	g_hash_table_remove(wispr_portal_list, GINT_TO_POINTER(index));
+
+	wispr_portal = g_hash_table_lookup(wispr_portal_list,
+					GINT_TO_POINTER(index));
+	if (!wispr_portal)
+		return;
+
+	if (wispr_portal->ipv4_context) {
+		if (service == wispr_portal->ipv4_context->service)
+			g_hash_table_remove(wispr_portal_list,
+					GINT_TO_POINTER(index));
+	}
+
+	if (wispr_portal->ipv6_context) {
+		if (service == wispr_portal->ipv6_context->service)
+			g_hash_table_remove(wispr_portal_list,
+					GINT_TO_POINTER(index));
+	}
 }
 
 int __connman_wispr_init(void)

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -92,7 +92,7 @@ struct connman_wispr_portal {
 
 static bool wispr_portal_web_result(GWebResult *result, gpointer user_data);
 
-static GHashTable *wispr_portal_list = NULL;
+static GHashTable *wispr_portal_hash = NULL;
 
 static void connman_wispr_message_init(struct connman_wispr_message *msg)
 {
@@ -586,7 +586,7 @@ static void wispr_portal_browser_reply_cb(struct connman_service *service,
 	if (index < 0)
 		return;
 
-	wispr_portal = g_hash_table_lookup(wispr_portal_list,
+	wispr_portal = g_hash_table_lookup(wispr_portal_hash,
 					GINT_TO_POINTER(index));
 	if (!wispr_portal)
 		return;
@@ -982,21 +982,21 @@ int __connman_wispr_start(struct connman_service *service,
 
 	DBG("service %p", service);
 
-	if (!wispr_portal_list)
+	if (!wispr_portal_hash)
 		return -EINVAL;
 
 	index = __connman_service_get_index(service);
 	if (index < 0)
 		return -EINVAL;
 
-	wispr_portal = g_hash_table_lookup(wispr_portal_list,
+	wispr_portal = g_hash_table_lookup(wispr_portal_hash,
 					GINT_TO_POINTER(index));
 	if (!wispr_portal) {
 		wispr_portal = g_try_new0(struct connman_wispr_portal, 1);
 		if (!wispr_portal)
 			return -ENOMEM;
 
-		g_hash_table_replace(wispr_portal_list,
+		g_hash_table_replace(wispr_portal_hash,
 					GINT_TO_POINTER(index), wispr_portal);
 	}
 
@@ -1034,7 +1034,7 @@ void __connman_wispr_stop(struct connman_service *service)
 
 	DBG("service %p", service);
 
-	if (!wispr_portal_list)
+	if (!wispr_portal_hash)
 		return;
 
 	index = __connman_service_get_index(service);
@@ -1043,7 +1043,7 @@ void __connman_wispr_stop(struct connman_service *service)
 
 	connman_agent_cancel(service);
 
-	wispr_portal = g_hash_table_lookup(wispr_portal_list,
+	wispr_portal = g_hash_table_lookup(wispr_portal_hash,
 					GINT_TO_POINTER(index));
 	if (!wispr_portal)
 		return;
@@ -1052,14 +1052,14 @@ void __connman_wispr_stop(struct connman_service *service)
 	     service == wispr_portal->ipv4_context->service) ||
 	    (wispr_portal->ipv6_context &&
 	     service == wispr_portal->ipv6_context->service))
-		g_hash_table_remove(wispr_portal_list, GINT_TO_POINTER(index));
+		g_hash_table_remove(wispr_portal_hash, GINT_TO_POINTER(index));
 }
 
 int __connman_wispr_init(void)
 {
 	DBG("");
 
-	wispr_portal_list = g_hash_table_new_full(g_direct_hash,
+	wispr_portal_hash = g_hash_table_new_full(g_direct_hash,
 						g_direct_equal, NULL,
 						free_connman_wispr_portal);
 
@@ -1070,6 +1070,6 @@ void __connman_wispr_cleanup(void)
 {
 	DBG("");
 
-	g_hash_table_destroy(wispr_portal_list);
-	wispr_portal_list = NULL;
+	g_hash_table_destroy(wispr_portal_hash);
+	wispr_portal_hash = NULL;
 }

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -1047,12 +1047,8 @@ int __connman_wispr_start(struct connman_service *service,
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
 		wp_context = wispr_portal->ipv4_context;
-	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
+	else
 		wp_context = wispr_portal->ipv6_context;
-	else {
-		err = -EINVAL;
-		goto free_wp;
-	}
 
 	/* If there is already an existing context, we wipe it */
 	if (wp_context)

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -608,9 +608,9 @@ static void wispr_portal_browser_reply_cb(struct connman_service *service,
 	struct connman_wispr_portal *wispr_portal;
 	int index;
 
-	DBG("authentication_done %d", authentication_done);
+	DBG("");
 
-	if (!service || !wp_context || !authentication_done)
+	if (!service || !wp_context)
 		return;
 
 	/*

--- a/connman/src/wispr.c
+++ b/connman/src/wispr.c
@@ -928,7 +928,6 @@ static gboolean no_proxy_callback(gpointer user_data)
 static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
 {
 	enum connman_service_proxy_method proxy_method;
-	enum connman_service_type service_type;
 	char *interface = NULL;
 	char **nameservers = NULL;
 	int if_index;
@@ -937,23 +936,6 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
 
 	DBG("wispr/portal context %p", wp_context);
 	DBG("service %p", wp_context->service);
-
-	service_type = connman_service_get_type(wp_context->service);
-
-	switch (service_type) {
-	case CONNMAN_SERVICE_TYPE_ETHERNET:
-	case CONNMAN_SERVICE_TYPE_WIFI:
-	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
-	case CONNMAN_SERVICE_TYPE_CELLULAR:
-	case CONNMAN_SERVICE_TYPE_GADGET:
-		break;
-	case CONNMAN_SERVICE_TYPE_UNKNOWN:
-	case CONNMAN_SERVICE_TYPE_SYSTEM:
-	case CONNMAN_SERVICE_TYPE_GPS:
-	case CONNMAN_SERVICE_TYPE_VPN:
-	case CONNMAN_SERVICE_TYPE_P2P:
-		return -EOPNOTSUPP;
-	}
 
 	interface = connman_service_get_interface(wp_context->service);
 	if (!interface)
@@ -1026,12 +1008,27 @@ int __connman_wispr_start(struct connman_service *service,
 {
 	struct connman_wispr_portal_context *wp_context = NULL;
 	struct connman_wispr_portal *wispr_portal = NULL;
-	int index;
+	int index, err;
 
 	DBG("service %p", service);
 
 	if (!wispr_portal_hash)
 		return -EINVAL;
+
+	switch (connman_service_get_type(service)) {
+	case CONNMAN_SERVICE_TYPE_ETHERNET:
+	case CONNMAN_SERVICE_TYPE_WIFI:
+	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
+	case CONNMAN_SERVICE_TYPE_CELLULAR:
+	case CONNMAN_SERVICE_TYPE_GADGET:
+		break;
+	case CONNMAN_SERVICE_TYPE_UNKNOWN:
+	case CONNMAN_SERVICE_TYPE_SYSTEM:
+	case CONNMAN_SERVICE_TYPE_GPS:
+	case CONNMAN_SERVICE_TYPE_VPN:
+	case CONNMAN_SERVICE_TYPE_P2P:
+		return -EOPNOTSUPP;
+	}
 
 	index = __connman_service_get_index(service);
 	if (index < 0)
@@ -1052,16 +1049,20 @@ int __connman_wispr_start(struct connman_service *service,
 		wp_context = wispr_portal->ipv4_context;
 	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
 		wp_context = wispr_portal->ipv6_context;
-	else
-		return -EINVAL;
+	else {
+		err = -EINVAL;
+		goto free_wp;
+	}
 
 	/* If there is already an existing context, we wipe it */
 	if (wp_context)
 		wispr_portal_context_unref(wp_context);
 
 	wp_context = create_wispr_portal_context();
-	if (!wp_context)
-		return -ENOMEM;
+	if (!wp_context) {
+		err = -ENOMEM;
+		goto free_wp;
+	}
 
 	wp_context->service = connman_service_ref(service);
 	wp_context->type = type;
@@ -1072,7 +1073,14 @@ int __connman_wispr_start(struct connman_service *service,
 	else
 		wispr_portal->ipv6_context = wp_context;
 
-	return wispr_portal_detect(wp_context);
+	err = wispr_portal_detect(wp_context);
+	if (err)
+		goto free_wp;
+	return 0;
+
+free_wp:
+	g_hash_table_remove(wispr_portal_hash, GINT_TO_POINTER(index));
+	return err;
 }
 
 void __connman_wispr_stop(struct connman_service *service)


### PR DESCRIPTION
[connman] Synchronize wispr from upstream. JB#59298

This set of commits mainly addresses the CVE-2022-32293. In addition many
other related commits are taken from upstream to avoid diverging even more
than this currently is. This brings wispr.c closer to the upstream version.

Commits directly fixing CVE-2022-32293:
8f66eb5d94d6d27126cada3566363f4ba3f987b5 
7f7176b8db269cae7cd66b003bb7d6c38340f6a8
2a3f816bd188735feead63b9f68c54afef1ffe89