### PR TITLE
[vpn] Add association state to fix dialog timeout issue. Fixes JB#59447

### DIFF
--- a/connman/doc/vpn-connection-api.txt
+++ b/connman/doc/vpn-connection-api.txt
@@ -104,8 +104,8 @@ Properties	string State [readonly]
 
 			The connection state information.
 
-			Valid states are "idle", "failure", "configuration",
-			"ready", "disconnect".
+			Valid states are "idle", "failure", "association",
+			"configuration", "ready", "disconnect".
 
 		string Type [readonly]
 
@@ -239,14 +239,14 @@ Properties	string State [readonly]
 
 			This value defines the amount of authentication errors
 			that are allowed before informing VPN agent to clear
-			the credentials in case there was a previous succesful
+			the credentials in case there was a previous successful
 			VPN connection made within one hour. This is to be used
 			with providers that allow only one login from one
 			account at a time to prevent clearing of credentials
 			when networks are rapidly changed. This value is used
 			as an integer and if unset this default to "1" for all
 			except OpenVPN that uses value "10". Setting value "0"
-			disables the feature for the provider. 
+			disables the feature for the provider.
 
 		There can be other properties also but as the VPN
 		technologies are so different, they have different

--- a/connman/doc/vpn-overview.txt
+++ b/connman/doc/vpn-overview.txt
@@ -54,7 +54,7 @@ is established (meaning VPN client has managed to create a connection
 to VPN server), then State property is set to "ready" and PropertyChanged
 signal is sent. If the connection cannot be established, then
 State property is set to "failure".
-After successfull connection, the relevant connection properties are sent
+After successful connection, the relevant connection properties are sent
 by PropertyChanged signal; like IPv[4|6] information, the index of the
 VPN tunneling interface (if there is any), nameserver information,
 server specified routes etc.
@@ -66,7 +66,9 @@ VPN agent interface described in vpn-agent-api.txt is used for
 interaction between the connectivity UI and ConnMan. A VPN agent
 registered via Management interface gets requests from the VPN plugins
 to input credentials or other authentication information for the VPN
-connection and offers information about the VPN to be connected.
+connection and offers information about the VPN to be connected. When
+waiting for input via VPN agent the state of the VPN is "association"
+and after getting the input the state transitions to "connect".
 
 In addition to basic credentials, there are additional types of optional
 and control parameters. The user can dictate whether to store the

--- a/connman/include/provider.h
+++ b/connman/include/provider.h
@@ -48,6 +48,7 @@ enum connman_provider_state {
 	CONNMAN_PROVIDER_STATE_READY         = 3,
 	CONNMAN_PROVIDER_STATE_DISCONNECT    = 4,
 	CONNMAN_PROVIDER_STATE_FAILURE       = 5,
+	CONNMAN_PROVIDER_STATE_ASSOCIATION   = 6,
 };
 
 enum connman_provider_error {

--- a/connman/plugins/vpn.c
+++ b/connman/plugins/vpn.c
@@ -272,6 +272,13 @@ static bool provider_is_connected(struct connection_data *data)
 			g_str_equal(data->state, "configuration"));
 }
 
+static bool provider_is_connected_or_connecting(struct connection_data *data)
+{
+	return data && (g_str_equal(data->state, "ready") ||
+			g_str_equal(data->state, "configuration") ||
+			g_str_equal(data->state, "association"));
+}
+
 static void set_provider_state(struct connection_data *data)
 {
 	enum connman_provider_state state = CONNMAN_PROVIDER_STATE_UNKNOWN;
@@ -280,7 +287,11 @@ static void set_provider_state(struct connection_data *data)
 
 	DBG("provider %p new state %s", data->provider, data->state);
 
-	connected = provider_is_connected(data);
+	/*
+	 * To avoid clearing transport ident when VPN is waiting for agent
+	 * take also connecting state into account.
+	 */
+	connected = provider_is_connected_or_connecting(data);
 
 	if (g_str_equal(data->state, "ready")) {
 		state = CONNMAN_PROVIDER_STATE_READY;
@@ -1082,7 +1093,7 @@ static int provider_disconnect(struct connman_provider *provider)
 	if (!data)
 		return -EINVAL;
 
-	if (provider_is_connected(data))
+	if (provider_is_connected_or_connecting(data))
 		err = disconnect_provider(data);
 
 	if (data->call) {
@@ -1736,7 +1747,7 @@ static void destroy_provider(struct connection_data *data)
 {
 	DBG("data %p", data);
 
-	if (provider_is_connected(data))
+	if (provider_is_connected_or_connecting(data))
 		connman_provider_disconnect(data->provider);
 
 	connman_provider_set_data(data->provider, NULL);
@@ -2207,7 +2218,7 @@ static bool vpn_is_valid_transport(struct connman_service *transport)
 
 static void vpn_disconnect_check_provider(struct connection_data *data)
 {
-	if (provider_is_connected(data)) {
+	if (provider_is_connected_or_connecting(data)) {
 		/* With NULL service ident NULL is returned immediately */
 		struct connman_service *service =
 			connman_service_lookup_from_identifier

--- a/connman/plugins/vpn.c
+++ b/connman/plugins/vpn.c
@@ -158,6 +158,8 @@ static const char *get_string(struct connman_provider *provider,
 		return data->domain;
 	else if (g_str_equal(key, "Transport"))
 		return data->service_ident;
+	else if (g_str_equal(key, "State"))
+		return data->state;
 
 	return g_hash_table_lookup(data->setting_strings, key);
 }
@@ -285,6 +287,8 @@ static void set_provider_state(struct connection_data *data)
 		goto set;
 	} else if (g_str_equal(data->state, "configuration")) {
 		state = CONNMAN_PROVIDER_STATE_CONNECT;
+	} else if (g_str_equal(data->state, "association")) {
+		state = CONNMAN_PROVIDER_STATE_ASSOCIATION;
 	} else if (g_str_equal(data->state, "idle")) {
 		state = CONNMAN_PROVIDER_STATE_IDLE;
 	} else if (g_str_equal(data->state, "disconnect")) {

--- a/connman/src/agent.c
+++ b/connman/src/agent.c
@@ -201,7 +201,9 @@ static void agent_receive_message(DBusPendingCall *call, void *user_data)
 	if (dbus_message_is_error(reply,
 			"org.freedesktop.DBus.Error.Timeout") ||
 			dbus_message_is_error(reply,
-			"org.freedesktop.DBus.Error.TimedOut")) {
+			"org.freedesktop.DBus.Error.TimedOut") ||
+			dbus_message_is_error(reply,
+			"org.freedesktop.DBus.Error.NoReply")) {
 		send_cancel_request(agent, agent->pending);
 	}
 

--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -866,6 +866,8 @@ int __connman_service_disconnect(struct connman_service *service);
 int __connman_service_disconnect_all(void);
 void __connman_service_set_active_session(bool enable, GSList *list);
 void __connman_service_auto_connect(enum connman_service_connect_reason reason);
+void __connman_service_start_connect_timeout(struct connman_service *service,
+				bool restart);
 bool __connman_service_remove(struct connman_service *service);
 bool __connman_service_is_provider_pending(struct connman_service *service);
 void __connman_service_set_provider_pending(struct connman_service *service,

--- a/connman/src/provider.c
+++ b/connman/src/provider.c
@@ -237,7 +237,10 @@ static int provider_indicate_state(struct connman_provider *provider,
 	case CONNMAN_SERVICE_STATE_UNKNOWN:
 	case CONNMAN_SERVICE_STATE_IDLE:
 	case CONNMAN_SERVICE_STATE_ASSOCIATION:
+		break;
 	case CONNMAN_SERVICE_STATE_CONFIGURATION:
+		__connman_service_start_connect_timeout(provider->vpn_service,
+								true);
 		break;
 	case CONNMAN_SERVICE_STATE_READY:
 	case CONNMAN_SERVICE_STATE_ONLINE:
@@ -429,9 +432,13 @@ int connman_provider_set_state(struct connman_provider *provider,
 		return -EINVAL;
 	case CONNMAN_PROVIDER_STATE_IDLE:
 		return set_connected(provider, false);
-	case CONNMAN_PROVIDER_STATE_CONNECT:
+	case CONNMAN_PROVIDER_STATE_ASSOCIATION:
+		/* Connect timeout is not effective for VPNs in this state */
 		return provider_indicate_state(provider,
 					CONNMAN_SERVICE_STATE_ASSOCIATION);
+	case CONNMAN_PROVIDER_STATE_CONNECT:
+		return provider_indicate_state(provider,
+					CONNMAN_SERVICE_STATE_CONFIGURATION);
 	case CONNMAN_PROVIDER_STATE_READY:
 		return set_connected(provider, true);
 	case CONNMAN_PROVIDER_STATE_DISCONNECT:

--- a/connman/vpn/plugins/vpn.h
+++ b/connman/vpn/plugins/vpn.h
@@ -38,6 +38,7 @@ enum vpn_state {
 	VPN_STATE_DISCONNECT    = 4,
 	VPN_STATE_FAILURE       = 5,
 	VPN_STATE_AUTH_FAILURE  = 6,
+	VPN_STATE_ASSOCIATION   = 7,
 };
 
 struct vpn_driver {

--- a/connman/vpn/vpn-agent.c
+++ b/connman/vpn/vpn-agent.c
@@ -259,8 +259,12 @@ int vpn_agent_check_and_process_reply_error(DBusMessage *reply,
 
 	dbus_error_init(&error);
 
-	if (!dbus_set_error_from_message(&error, reply))
+	if (!dbus_set_error_from_message(&error, reply)) {
+		DBG("Dialog without error, set provider %p to CONNECT",
+					provider);
+		vpn_provider_set_state(provider, VPN_PROVIDER_STATE_CONNECT);
 		return 0;
+	}
 
 	DBG("D-Bus error: %s", error.name);
 

--- a/connman/vpn/vpn-provider.h
+++ b/connman/vpn/vpn-provider.h
@@ -49,6 +49,12 @@ enum vpn_provider_state {
 	VPN_PROVIDER_STATE_READY         = 3,
 	VPN_PROVIDER_STATE_DISCONNECT    = 4,
 	VPN_PROVIDER_STATE_FAILURE       = 5,
+	/*
+	 * Special state to indicate that user interaction is being waited for
+	 * and disconnect timeout in connmand should not terminate this VPN but
+	 * to let the agent timeout handle the case.
+	 */
+	VPN_PROVIDER_STATE_ASSOCIATION   = 6,
 };
 
 enum vpn_provider_error {


### PR DESCRIPTION
This fixes the VPN dialog timeout happening too early. The cause for it was
that connmand did connection timeout for every type of service after 120s
interval. The configuration value InputRequestTimeout for vpnd in
connman-vpn.conf was not, therefore, followed and the setting had no effect.

In order to fix the issue VPN connections now have association state in which
the connection timeout of connmand is not in effect. This state is the new
initial state for VPN connections to which they enter after getting connect
request. In this state VPNs request the credentials of sorts from the VPN
agent, which in turn requests missing content from user. The input request
timeout set in the settings is therefore followed as the VPN is not really yet
connected to the server and is not subject to connection timeout.

Every other service in ConnMan already implements Association state and prior
to this there was a possible confusion with VPNs having CONNECT state as
configuration state in vpnd but in ConnMan the state of the service would have
been set to association. These changes make the states to be equal both in
connmand and vpnd.