### PR TITLE
[connman] Apply upstream fix for HTTP response crash. Fixes JB#59564

### DIFF
--- a/connman/gweb/gweb.c
+++ b/connman/gweb/gweb.c
@@ -809,6 +809,9 @@ static void handle_multi_line(struct web_session *session)
 	char *str;
 	gchar *value;
 
+	if (!session->result.last_key)
+		return;
+
 	str = session->current_header->str;
 
 	if (str[0] != ' ' && str[0] != '\t')

--- a/connman/src/main.c
+++ b/connman/src/main.c
@@ -518,7 +518,7 @@ static void parse_config(GKeyFile *config)
 	parse_perm(config, group, CONF_UMASK, &connman_settings.umask);
 
 	connman_settings.ipv4_status_url = __connman_config_get_string(config,
-					group, CONF_STATUS_URL_IPV4, &error);
+					group, CONF_STATUS_URL_IPV4, NULL);
 
 	connman_settings.ipv6_status_url = __connman_config_get_string(config,
 					group, CONF_STATUS_URL_IPV6, NULL);


### PR DESCRIPTION
Applies an upstream patch: "gweb: Fix crash on malformed http response" 
[22901212105055b24f73504a74f5a57eee809777](https://git.kernel.org/pub/scm/network/connman/connman.git/commit/gweb/gweb.c?id=22901212105055b24f73504a74f5a57eee809777)

to address issue caused by a CVE-fix "gweb: Fix OOB write in received_data()"
[d1a5ede5d255bde8ef707f8441b997563b9312bd](https://git.kernel.org/pub/scm/network/connman/connman.git/commit/gweb/gweb.c?id=d1a5ede5d255bde8ef707f8441b997563b9312bd).

Also drop the use of errors for reading IPv4 status url from the configuration file. With
IPv6 this was also ignored and the default is being returned when the status url is not
set. This caused a Glib warning as GError was not cleared.