### PR TITLE
[ofono] Increase delayed connect wait to 5 seconds. JB#58538 JB#59714

### DIFF
--- a/connman/plugins/sailfish_ofono.c
+++ b/connman/plugins/sailfish_ofono.c
@@ -100,8 +100,12 @@ enum connctx_handler_id {
 #define ONLINE_CHECK_SEC  (2)
 /* Timeout for delayed set connected call, in milliseconds. */
 #define DELAYED_CONNECT_TIMEOUT_MS (100)
-/* Wait for approx 2s for address information from ofono. */
-#define DELAYED_CONNECT_LIMIT (2000 / DELAYED_CONNECT_TIMEOUT_MS)
+/*
+ *  Wait for approx 5s for address information from ofono. This defines the
+ *  amount of cycles for delayed connect to run with the defined
+ *  DELAYED_CONNECT_TIMEOUT_MS wait set for one cycle.
+ */
+#define DELAYED_CONNECT_LIMIT (5000 / DELAYED_CONNECT_TIMEOUT_MS)
 
 struct modem_data {
 	OfonoModem *modem;


### PR DESCRIPTION
It seems that in some cases with VoLTE the too short wait for IPv4 connection information from the operator may be the cause for not having IPv4 connectivity at all. This fix was done previously to address certain error situations with some operators and the limit was set to 2 seconds, it might be that with VoLTE we need longer wait for the IPv4 information in dual mode.