### PR TITLE
[connman] Apply regdom changes to powering up devices. Fixes JB#55556

### DIFF
--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -672,6 +672,7 @@ void __connman_technology_remove_interface(enum connman_service_type type,
 				int index, const char *ident);
 void __connman_technology_notify_regdom_by_device(struct connman_device *device,
 						int result, const char *alpha2);
+const char *__connman_technology_get_regdom(enum connman_service_type type);
 const char *__connman_technology_get_tethering_ident(
 					struct connman_technology *tech);
 enum connman_service_type __connman_technology_get_type(

--- a/connman/src/device.c
+++ b/connman/src/device.c
@@ -589,6 +589,7 @@ int connman_device_set_powered(struct connman_device *device,
 						bool powered)
 {
 	enum connman_service_type type;
+	const char *alpha2;
 
 	DBG("device %p powered %d", device, powered);
 
@@ -606,6 +607,15 @@ int connman_device_set_powered(struct connman_device *device,
 	if (!device->powered) {
 		__connman_technology_disabled(type);
 		return 0;
+	} else {
+		/*
+		 * Check if technology has regdom set and apply it This may
+		 * have been changed when the device was powered off and, thus
+		 * the new regdom has not been set.
+		 */
+		alpha2 = __connman_technology_get_regdom(type);
+		if (alpha2)
+			connman_device_set_regdom(device, alpha2);
 	}
 
 	__connman_technology_enabled(type);

--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -50,6 +50,8 @@ static unsigned int global_offlinemode_override; /* Technology bitmask */
 struct connman_access_tech_policy *tech_access_policy;
 static unsigned int enable_delayed_ids[MAX_CONNMAN_SERVICE_TYPES] = { 0 };
 
+static char *global_regdom = NULL;
+
 struct connman_rfkill {
 	unsigned int index;
 	enum connman_service_type type;
@@ -366,7 +368,13 @@ int connman_technology_set_regdom(const char *alpha2)
 					driver->set_regdom(technology, alpha2);
 			}
 		}
+
+		/* Save regdom for this technology */
+		connman_technology_regdom_notify(technology, alpha2);
 	}
+
+	g_free(global_regdom);
+	global_regdom = g_strdup(alpha2);
 
 	return 0;
 }
@@ -385,6 +393,22 @@ static struct connman_technology *technology_find(enum connman_service_type type
 	}
 
 	return NULL;
+}
+
+const char *__connman_technology_get_regdom(enum connman_service_type type)
+{
+	struct connman_technology *technology;
+
+	DBG("type %d/%s", type, get_name(type));
+
+	technology = technology_find(type);
+	if (!technology)
+		return NULL;
+
+	if (technology->regdom)
+		return technology->regdom;
+
+	return global_regdom;
 }
 
 bool connman_technology_get_wifi_tethering(const char **ssid,
@@ -1434,6 +1458,7 @@ static struct connman_technology *technology_get(enum connman_service_type type)
 	technology_load(technology);
 	technology_list = g_slist_prepend(technology_list, technology);
 	technology->driver_list = tech_drivers;
+	technology->regdom = g_strdup(global_regdom);
 
 	for (list = tech_drivers; list; list = list->next) {
 		driver = list->data;
@@ -2322,4 +2347,6 @@ void __connman_technology_cleanup(void)
 
 	__connman_access_tech_policy_free(tech_access_policy);
 	tech_access_policy = NULL;
+
+	g_free(global_regdom);
 }

--- a/connman/src/timezone.c
+++ b/connman/src/timezone.c
@@ -41,7 +41,7 @@
 
 #define ETC_SYSCONFIG_CLOCK	"/etc/sysconfig/clock"
 #define USR_SHARE_ZONEINFO	"/usr/share/zoneinfo"
-#define USR_SHARE_ZONEINFO_MAP	USR_SHARE_ZONEINFO "/zone1970.tab"
+#define USR_SHARE_ZONEINFO_MAP	USR_SHARE_ZONEINFO "/zone.tab"
 
 static char *read_key_file(const char *pathname, const char *key)
 {

--- a/connman/unit/test-device.c
+++ b/connman/unit/test-device.c
@@ -243,6 +243,11 @@ int __connman_technology_enabled(enum connman_service_type type)
 	}
 }
 
+const char *__connman_technology_get_regdom(enum connman_service_type type)
+{
+	return NULL;
+}
+
 // rtnl dummies
 
 static unsigned int watch_id = 42;


### PR DESCRIPTION
The devices, let alone technologies are not loaded nor set up yet when timezone
reads the current time and attempts to set up regulatory domain. This change
fixes the issue by saving the regulatory domain as a global for the
technologies which is then used by the device during power up.