### PR TITLE
WIP: Add VPN support to CLAT. JB#60276

### DIFF
--- a/connman/Makefile.am
+++ b/connman/Makefile.am
@@ -562,12 +562,12 @@ noinst_PROGRAMS += unit/test-blacklist_monitor
 TESTS += unit/test-blacklist_monitor
 endif
 
-if CLAT_TESTS
-unit_test_blacklist_monitor_CFLAGS = $(COVERAGE_OPT) $(AM_CFLAGS) \
-				@GLIB_CFLAGS@
-unit_test_blacklist_monitor_SOURCES = $(backtrace_sources) src/connman.h \
-				src/log.c plugins/clat.c unit/test-clat.c
-unit_test_blacklist_monitor_LDADD = @GLIB_LIBS@ @DBUS_LIBS@ -ldl
+if CLAT
+unit_test_clat_CFLAGS = $(COVERAGE_OPT) $(AM_CFLAGS) @GLIB_CFLAGS@
+unit_test_clat_SOURCES = $(backtrace_sources) src/connman.h \
+				src/log.c src/ipaddress.c unit/test-clat.c \
+				plugins/clat.c
+unit_test_clat_LDADD = @GLIB_LIBS@ -ldl
 noinst_PROGRAMS += unit/test-clat
 TESTS += unit/test-clat
 endif

--- a/connman/Makefile.am
+++ b/connman/Makefile.am
@@ -562,6 +562,16 @@ noinst_PROGRAMS += unit/test-blacklist_monitor
 TESTS += unit/test-blacklist_monitor
 endif
 
+if CLAT_TESTS
+unit_test_blacklist_monitor_CFLAGS = $(COVERAGE_OPT) $(AM_CFLAGS) \
+				@GLIB_CFLAGS@
+unit_test_blacklist_monitor_SOURCES = $(backtrace_sources) src/connman.h \
+				src/log.c plugins/clat.c unit/test-clat.c
+unit_test_blacklist_monitor_LDADD = @GLIB_LIBS@ @DBUS_LIBS@ -ldl
+noinst_PROGRAMS += unit/test-clat
+TESTS += unit/test-clat
+endif
+
 if WISPR
 noinst_PROGRAMS += tools/wispr
 

--- a/connman/Makefile.plugins
+++ b/connman/Makefile.plugins
@@ -354,3 +354,8 @@ if BLACKLIST_MONITOR
 builtin_modules += blacklist_monitor
 builtin_sources += plugins/blacklist_monitor.c
 endif
+
+if CLAT
+builtin_modules += clat
+builtin_sources += plugins/clat.c
+endif

--- a/connman/configure.ac
+++ b/connman/configure.ac
@@ -597,6 +597,11 @@ AC_ARG_ENABLE(blacklist-monitor,
 			[enable_blacklist_monitor=${enableval}], [enable_blacklist_monitor="no"])
 AM_CONDITIONAL(BLACKLIST_MONITOR, test "${enable_blacklist_monitor}" != "no")
 
+AC_ARG_ENABLE(clat,
+	AC_HELP_STRING([--enable-clat], [enable CLAT plugin]),
+			[enable_clat=${enableval}], [enable_clat="no"])
+AM_CONDITIONAL(CLAT, test "${enable_clat}" != "no")
+
 if (test "${enable_client}" != "no"); then
 	AC_CHECK_HEADERS(readline/readline.h, dummy=yes,
 		AC_MSG_ERROR(readline header files are required))

--- a/connman/include/inet.h
+++ b/connman/include/inet.h
@@ -45,7 +45,13 @@ int connman_inet_add_host_route(int index, const char *host, const char *gateway
 int connman_inet_del_host_route(int index, const char *host);
 int connman_inet_add_network_route(int index, const char *host, const char *gateway,
 					const char *netmask);
+int connman_inet_add_network_route_with_metric(int index, const char *host,
+					const char *gateway,
+					const char *netmask, short metric,
+					unsigned long mtu);
 int connman_inet_del_network_route(int index, const char *host);
+int connman_inet_del_network_route_with_metric(int index, const char *host,
+					short metric);
 int connman_inet_clear_gateway_address(int index, const char *gateway);
 int connman_inet_set_gateway_interface(int index);
 int connman_inet_clear_gateway_interface(int index);

--- a/connman/include/inet.h
+++ b/connman/include/inet.h
@@ -81,6 +81,9 @@ int connman_inet_clear_ipv6_gateway_interface(int index);
 int connman_inet_add_to_bridge(int index, const char *bridge);
 int connman_inet_remove_from_bridge(int index, const char *bridge);
 
+int connman_inet_rmtun(const char *ifname, int flags);
+int connman_inet_mktun(const char *ifname, int flags);
+
 int connman_inet_set_mtu(int index, int mtu);
 int connman_inet_setup_tunnel(char *tunnel, int mtu);
 int connman_inet_create_tunnel(char **iface);

--- a/connman/include/inet.h
+++ b/connman/include/inet.h
@@ -92,6 +92,14 @@ int connman_inet_ipv6_get_route_addresses(int index, char **network,
 							char **netmask,
 							char **destination);
 
+struct nd_neighbor_advert *hdr;
+typedef void (*connman_inet_ns_cb_t) (struct nd_neighbor_advert *reply,
+					unsigned int length,
+					struct in6_addr *addr,
+					void *user_data);
+int connman_inet_ipv6_do_dad(int index, int timeout_ms,struct in6_addr *addr,
+				connman_inet_ns_cb_t callback, void *user_data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/connman/include/ipconfig.h
+++ b/connman/include/ipconfig.h
@@ -54,6 +54,8 @@ struct connman_ipconfig;
 
 enum connman_ipconfig_type connman_ipconfig_get_config_type(
 					struct connman_ipconfig *ipconfig);
+struct connman_ipaddress *connman_ipconfig_get_ipaddress(
+					struct connman_ipconfig *ipconfig);
 
 #ifdef __cplusplus
 }

--- a/connman/include/nat.h
+++ b/connman/include/nat.h
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Connection Manager
+ *
+ *  Copyright (C) 2023 Jolla Ltd. All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __CONNMAN_NAT_H
+#define __CONNMAN_NAT_H
+
+#include <connman/ipconfig.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * SECTION:NAT
+ * @title: NAT setup premitives
+ * @short_description: Functions for NAT handling
+ */
+
+int connman_nat_enable_double_nat_override(const char *ifname,
+						const char *ipaddr_range,
+						unsigned char ipaddr_netmask);
+void connman_nat_disable_double_nat_override(const char *ifname);
+int connman_nat6_prepare(struct connman_ipconfig *ipconfig,
+						const char *ipv6_address,
+						unsigned char ipv6_prefixlen,
+						const char *ifname_in,
+						bool enable_ndproxy);
+void connman_nat6_restore(struct connman_ipconfig *ipconfig);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CONNMAN_IPCONFIG_H */

--- a/connman/include/service.h
+++ b/connman/include/service.h
@@ -152,6 +152,8 @@ void connman_service_create_ip4config(struct connman_service *service,
 								int index);
 void connman_service_create_ip6config(struct connman_service *service,
 								int index);
+struct connman_ipconfig *connman_service_get_ipconfig(
+				struct connman_service *service, int family);
 
 enum connman_ipconfig_method connman_service_get_ipconfig_method(
 					struct connman_service *service,

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -576,7 +576,11 @@ static struct prefix_entry *new_prefix_entry(const char *address)
 	if (tokens)
 		g_strfreev(tokens);
 
-	if (entry->prefixlen > 128 || entry->prefixlen < 16) {
+	/*
+	 * Addresses with < 16 prefixlen should not be possible, also ignore
+	 * single address prefixes as there is no room for additional address.
+	 */
+	if (entry->prefixlen > 120 || entry->prefixlen < 16) {
 		DBG("Invalid prefixlen %u", entry->prefixlen);
 		g_free(entry);
 		return NULL;
@@ -644,7 +648,7 @@ static int assign_clat_prefix(struct clat_data *data, char **results)
 
 	/* A prefix exists already */
 	if (data->clat_prefix) {
-		if (g_strcmp0(data->clat_prefix, entry->prefix) &&
+		if (g_strcmp0(data->clat_prefix, entry->prefix) ||
 				data->clat_prefixlen != entry->prefixlen) {
 			DBG("changing existing prefix %s/%u -> %s/%u",
 						data->clat_prefix,
@@ -809,12 +813,21 @@ static gboolean run_prefix_query(gpointer user_data)
 	if (!data)
 		return G_SOURCE_REMOVE;
 
+	data->prefix_query_id = 0;
+
 	if (clat_task_do_prefix_query(data)) {
 		DBG("failed to run prefix query");
 		return G_SOURCE_REMOVE;
 	}
 
-	return G_SOURCE_CONTINUE;
+	data->prefix_query_id = g_timeout_add(PREFIX_QUERY_TIMEOUT,
+							run_prefix_query, data);
+	if (!data->prefix_query_id) {
+		connman_error("CLAT failed to continue periodic prefix query");
+		return G_SOURCE_REMOVE;
+	}
+
+	return G_SOURCE_REMOVE;
 }
 
 static int clat_task_start_periodic_query(struct clat_data *data)

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -60,6 +60,7 @@ enum tethering_state {
 
 struct clat_data {
 	struct connman_service *service;
+	struct connman_ipconfig *ipv6config;
 	struct connman_task *task;
 	enum clat_state state;
 	char *isp_64gateway;
@@ -1273,6 +1274,7 @@ static int clat_task_configure(struct clat_data *data)
 		return -ENOENT;
 	}
 
+	/* Call to nat6 prepare increases the ipconfig reference for itself*/
 	err = connman_nat6_prepare(ipconfig, data->address,
 						data->addr_prefixlen,
 						TAYGA_CLAT_DEVICE, true);
@@ -1281,12 +1283,19 @@ static int clat_task_configure(struct clat_data *data)
 		return err;
 	}
 
-	//$ ip route add 2a00:e18:8000:6cd::c1a7 dev clat
-	// TODO default route or...?
+	/*
+	 * We keep this because the service can reset the pointer to its
+	 * ipconfig before tayga process has properly terminated and ipconfig
+	 * is needed for nat6 restore. As the struct itself is kept by nat.c
+	 * as an added reference we can safely use this between nat6 prepare
+	 * and restore.
+	 */
+	data->ipv6config = ipconfig;
+
 	connman_inet_add_ipv6_network_route_with_metric(index, data->address,
 						NULL, data->addr_prefixlen,
 						CLAT_IPv6_METRIC);
-	//$ ip address add 192.0.0.2 dev clat
+
 	if (clat_settings.clat_device_use_netmask)
 		netmask = cidr_to_str(CLAT_IPv4ADDR_NETMASK);
 
@@ -1294,7 +1303,6 @@ static int clat_task_configure(struct clat_data *data)
 	connman_ipaddress_set_ipv4(ipaddress, CLAT_IPv4ADDR, netmask, NULL);
 	connman_inet_set_address(index, ipaddress);
 
-	//$ ip -4 route add default dev clat
 	/* Set no address, all traffic should be forwarded to the device */
 	connman_inet_add_network_route_with_metric(index, CLAT_IPv4_INADDR_ANY,
 							CLAT_IPv4_INADDR_ANY,
@@ -1405,17 +1413,17 @@ static int clat_task_stop_dad(struct clat_data *data)
 
 static int clat_task_post_configure(struct clat_data *data)
 {
-	struct connman_ipconfig *ipconfig;
 	struct connman_ipaddress *ipaddress;
 	char *netmask = NULL;
 	int index;
 
-	ipconfig = connman_service_get_ipconfig(data->service, AF_INET6);
-	if (ipconfig)
-		connman_nat6_restore(ipconfig, data->address,
-							data->addr_prefixlen);
+	DBG("ipconfig %p", data->ipv6config);
 
-	DBG("ipconfig %p", ipconfig);
+	if (data->ipv6config) {
+		/* Restore releases the reference to ipconfig, set it to NULL */
+		connman_nat6_restore(data->ipv6config);
+		data->ipv6config = NULL;
+	}
 
 	index = connman_inet_ifindex(TAYGA_CLAT_DEVICE);
 	if (index < 0) {

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -87,10 +87,11 @@ struct clat_data {
 #define IPv4ADDR_NETMASK		29		/* from RFC 7335 */
 #define CLAT_INADDR_ANY		"0.0.0.0"
 #define CLAT_IPv4_METRIC		2049		/* Set as value -1 */
+#define CLAT_IPv4_ROUTE_MTU		1260		/* from clatd */
 #define CLAT_IPv6_METRIC		1024
 #define CLAT_SUFFIX			"c1a7"
 
-#define PREFIX_DAD_TIMEOUT		10000		/* 10 seconds */
+#define PREFIX_QUERY_TIMEOUT		10000		/* 10 seconds */
 #define DAD_TIMEOUT			600000		/* 10 minutes */
 
 static const char GLOBAL_PREFIX[] = "64:ff9b::";
@@ -357,8 +358,6 @@ static void clat_data_clear(struct clat_data *data)
 		return;
 
 	DBG("data %p", data);
-
-	destroy_task(data);
 
 	g_free(data->isp_64gateway);
 	data->isp_64gateway = NULL;
@@ -698,7 +697,7 @@ static void prefix_query_cb(GResolvResultStatus status,
 		break;
 	case -EHOSTDOWN:
 		DBG("failed to resolv %s, CLAT is not started", WKN_ADDRESS);
-		new_state = CLAT_STATE_FAILURE;
+		new_state = CLAT_STATE_STOPPED;
 		break;
 	default:
 		DBG("failed to assign prefix, error %d", err);
@@ -787,7 +786,7 @@ static int clat_task_start_periodic_query(struct clat_data *data)
 		return -EALREADY;
 	}
 
-	data->prefix_query_id = g_timeout_add(PREFIX_DAD_TIMEOUT,
+	data->prefix_query_id = g_timeout_add(PREFIX_QUERY_TIMEOUT,
 							run_prefix_query, data);
 	if (data->prefix_query_id <= 0) {
 		connman_error("CLAT failed to start periodic prefix query");
@@ -915,12 +914,6 @@ static int clat_task_pre_configure(struct clat_data *data)
 	DBG("Address IPv6 %s/%u -> CLAT address %s", data->ipv6address,
 					data->ipv6_prefixlen, data->address);
 
-	err = connman_nat6_prepare(ipconfig, TAYGA_CLAT_DEVICE, true);
-	if (err) {
-		connman_warn("CLAT failed to prepare nat and firewall %d", err);
-		return err;
-	}
-
 	clat_create_tayga_config(data);
 
 	if (create_task(data))
@@ -969,6 +962,7 @@ static char *cidr_to_str(unsigned char cidr_netmask)
 
 static int clat_task_start_tayga(struct clat_data *data)
 {
+	struct connman_ipconfig *ipconfig;
 	struct connman_ipaddress *ipaddress;
 	char *netmask = NULL;
 	int err;
@@ -990,6 +984,20 @@ static int clat_task_start_tayga(struct clat_data *data)
 		return err;
 	}
 
+	ipconfig = connman_service_get_ipconfig(data->service, AF_INET6);
+	if (!ipconfig) {
+		DBG("No IPv6 ipconfig");
+		return -ENOENT;
+	}
+
+	err = connman_nat6_prepare(ipconfig, data->address,
+						data->addr_prefixlen,
+						TAYGA_CLAT_DEVICE, true);
+	if (err) {
+		connman_warn("CLAT failed to prepare nat and firewall %d", err);
+		return err;
+	}
+
 	//$ ip route add 2a00:e18:8000:6cd::c1a7 dev clat
 	// TODO default route or...?
 	connman_inet_add_ipv6_network_route_with_metric(index, data->address,
@@ -1008,7 +1016,8 @@ static int clat_task_start_tayga(struct clat_data *data)
 	connman_inet_add_network_route_with_metric(index, CLAT_INADDR_ANY,
 							CLAT_INADDR_ANY,
 							CLAT_INADDR_ANY,
-							CLAT_IPv4_METRIC);
+							CLAT_IPv4_METRIC,
+							CLAT_IPv4_ROUTE_MTU);
 	connman_ipaddress_free(ipaddress);
 	g_free(netmask);
 
@@ -1104,7 +1113,8 @@ static int clat_task_post_configure(struct clat_data *data)
 
 	ipconfig = connman_service_get_ipconfig(data->service, AF_INET6);
 	if (ipconfig)
-		connman_nat6_restore(ipconfig);
+		connman_nat6_restore(ipconfig, data->address,
+							data->addr_prefixlen);
 
 	DBG("ipconfig %p", ipconfig);
 
@@ -1146,6 +1156,17 @@ static void clat_task_exit(struct connman_task *task, int exit_code,
 {
 	struct clat_data *data = user_data;
 	int err;
+
+	if (!data) {
+		DBG("data gone, exit code %d after CLAT exit", exit_code);
+
+		if (task) {
+			DBG("destroying task %p", task);
+			connman_task_destroy(task);
+		}
+
+		return;
+	}
 
 	DBG("state %d/%s", data->state, state2string(data->state));
 
@@ -1297,7 +1318,11 @@ static int clat_run_task(struct clat_data *data)
 			data->state = CLAT_STATE_FAILURE;
 		}
 
-		data->state = CLAT_STATE_IDLE;
+		/*
+		 * RESTART comes after prefix query has been done, go directly
+		 * to PRE_CONFIGURE state.
+		 */
+		data->state = CLAT_STATE_PRE_CONFIGURE;
 		break;
 	}
 

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -425,14 +425,13 @@ static gboolean io_channel_cb(GIOChannel *source, GIOCondition condition,
 
 				break;
 			}
-		}
-
 		/*
 		 * Process needs restart, without interface post configure
 		 * only removes the nat6 rules.
 		 */
-		if (g_str_has_suffix(str, bad_state_suffix))
+		} else if (g_str_has_suffix(str, bad_state_suffix)) {
 			restart = true;
+		}
 
 		g_free(str);
 
@@ -440,10 +439,12 @@ static gboolean io_channel_cb(GIOChannel *source, GIOCondition condition,
 			data->state = CLAT_STATE_RESTART;
 
 			err = clat_run_task(data);
-			if (err)
+			if (err) {
 				connman_error("Interface lost and failed to "
 							"run CLAT restart %d",
 							err);
+				clat_stop(data);
+			}
 
 			return G_SOURCE_REMOVE;
 		}
@@ -972,8 +973,10 @@ static void prefix_query_cb(GResolvResultStatus status,
 		data->state = new_state;
 
 		err = clat_run_task(data);
-		if (err && err != -EALREADY)
+		if (err && err != -EALREADY) {
 			connman_error("failed to run CLAT, error %d", err);
+			clat_data_clear(data);
+		}
 	}
 }
 
@@ -1523,8 +1526,10 @@ static void clat_task_exit(struct connman_task *task, int exit_code,
 		}
 
 		err = clat_run_task(data);
-		if (err && err != -EALREADY)
+		if (err && err != -EALREADY) {
 			connman_error("failed to run CLAT, error %d", err);
+			break;
+		}
 
 		return;
 	case CLAT_STATE_POST_CONFIGURE:
@@ -1539,9 +1544,11 @@ static void clat_task_exit(struct connman_task *task, int exit_code,
 			data->do_restart = false;
 
 			err = clat_run_task(data);
-			if (err && err != -EALREADY)
-				connman_error("failed to run CLAT, error %d",
-									err);
+			if (err && err != -EALREADY) {
+				connman_error("failed to run CLAT restart, "
+							"error %d", err);
+				break;
+			}
 
 			return;
 		}
@@ -1672,6 +1679,12 @@ static int clat_run_task(struct clat_data *data)
 				 */
 				data->do_restart = false;
 				data->state = CLAT_STATE_PREFIX_QUERY;
+
+				/*
+				 * This will make sure that the task will stop.
+				 * If post configure reports -ENODEV it has not
+				 * set up the task yet. We can ignore the error.
+				 */
 				err = stop_task(data);
 				if (err)
 					DBG("Failed to stop task %p, continue",

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -318,16 +318,50 @@ static void close_io_channel(struct clat_data *data, GIOChannel *channel)
 	}
 }
 
+static int clat_run_task(struct clat_data *data);
+
+static int force_rmtun(const char *ifname)
+{
+	int index;
+	int err;
+
+	index = connman_inet_ifindex(ifname);
+	if (index < 0) {
+		connman_error("Cannot force-remove %s, no such interface",
+									ifname);
+		return -ENODEV;
+	}
+
+	err = connman_inet_ifdown(index);
+	if (err && err != -EALREADY)
+		connman_error("Cannot put %s down, trying to remove anyway",
+									ifname);
+
+	err = connman_inet_rmtun(TAYGA_CLAT_DEVICE);
+	if (err) {
+		connman_error("Failed to remove tun device %s",	ifname);
+		return err;
+	}
+
+	DBG("Forcefully removed persistent tun device %s", ifname);
+
+	return 0;
+}
+
 static gboolean io_channel_cb(GIOChannel *source, GIOCondition condition,
 			gpointer user_data)
 {
 	struct clat_data *data = user_data;
+	const char dev_busy_suffix[] = "aborting: Device or resource busy";
+	const char bad_state_suffix[] = "File descriptor in bad state";
 	char *str;
 	const char *type = (source == data->out_ch ? "STDOUT" :
 				(source == data->err_ch ? "STDERR" : "NaN"));
+	int err;
 
 	if (condition & (G_IO_IN | G_IO_PRI)) {
 		GIOStatus status;
+		bool restart = false;
 
 		status = g_io_channel_read_line(source, &str, NULL, NULL, NULL);
 		if (status != G_IO_STATUS_NORMAL && status != G_IO_STATUS_EOF) {
@@ -339,7 +373,63 @@ static gboolean io_channel_cb(GIOChannel *source, GIOCondition condition,
 
 		connman_info("CLAT %s: %s", clat_settings.tayga_bin, str);
 
+		/* This requires real hard removal of the device */
+		if (g_str_has_suffix(str, dev_busy_suffix)) {
+			switch (data->state) {
+			case CLAT_STATE_IDLE:
+			case CLAT_STATE_PREFIX_QUERY:
+			case CLAT_STATE_RUNNING:
+			case CLAT_STATE_RESTART:
+				connman_warn("State machine invalid, not"
+							"reacting to error");
+				break;
+			/*
+			 * Force remove the device and restart. Restart will
+			 * set the device first to POST_CONFIGURE state and
+			 * fails to remove the nonexistent device resulting in
+			 * stopping this task and returning to state that
+			 * preceeds PRE_CONFIGURE. After running the new task
+			 * when current task exits it starts with old config.
+			 */
+			case CLAT_STATE_PRE_CONFIGURE:
+				err = force_rmtun(TAYGA_CLAT_DEVICE);
+				if (!err)
+					restart = true;
+
+				break;
+			/* It may be possible to read the message late */
+			case CLAT_STATE_STOPPED:
+			case CLAT_STATE_FAILURE:
+			case CLAT_STATE_POST_CONFIGURE:
+				err = force_rmtun(TAYGA_CLAT_DEVICE);
+				if (err)
+					connman_error("Lingering tun device %s",
+							TAYGA_CLAT_DEVICE);
+
+				break;
+			}
+		}
+
+		/*
+		 * Process needs restart, without interface post configure
+		 * only removes the nat6 rules.
+		 */
+		if (g_str_has_suffix(str, bad_state_suffix))
+			restart = true;
+
 		g_free(str);
+
+		if (restart) {
+			data->state = CLAT_STATE_RESTART;
+
+			err = clat_run_task(data);
+			if (err)
+				connman_error("Interface lost and failed to "
+							"run CLAT restart %d",
+							err);
+
+			return G_SOURCE_REMOVE;
+		}
 	} else if (condition & (G_IO_ERR | G_IO_HUP)) {
 		DBG("%s Channel termination", type);
 		close_io_channel(data, source);
@@ -506,8 +596,6 @@ static int clat_create_tayga_config(struct clat_data *data)
 
 	return err;
 }
-
-static int clat_run_task(struct clat_data *data);
 
 static gboolean remove_resolv(gpointer user_data)
 {
@@ -1499,10 +1587,28 @@ static int clat_run_task(struct clat_data *data)
 
 		err = clat_task_post_configure(data);
 		if (err) {
-			connman_error("CLAT failed to create post-configure "
-								"task");
-			break;
+			/* If restarting CLAT the device may be gone already */
+			if (err == -ENODEV && data->do_restart) {
+				DBG("Device %s gone and restart required "
+							"ignore ENODEV err",
+							TAYGA_CLAT_DEVICE);
+				/*
+				 * Reset back to state to run pre configure 
+				 * and stop the task to it call exit function.
+				 * This will make tayga use existing settings.
+				 */
+				data->state = CLAT_STATE_PREFIX_QUERY;
+				if (data->task)
+					connman_task_stop(data->task);
+
+				return 0;
+			} else {
+				connman_error("CLAT failed to create"
+							"post-configure task");
+				break;
+			}
 		}
+
 		data->state = CLAT_STATE_POST_CONFIGURE;
 
 		break;

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -117,7 +117,7 @@ static struct {
 	.resolv_always_succeeds = false,
 
 	/* Add netmask to the CLAT device IPv4 address */
-	.clat_device_use_netmask = false,
+	.clat_device_use_netmask = true,
 
 	/* Write IPv6 address of the interface used to the tayga config */
 	.tayga_use_ipv6_conf = false,
@@ -814,7 +814,7 @@ static int clat_task_start_periodic_query(struct clat_data *data)
 
 	data->prefix_query_id = g_timeout_add(PREFIX_QUERY_TIMEOUT,
 							run_prefix_query, data);
-	if (data->prefix_query_id <= 0) {
+	if (!data->prefix_query_id) {
 		connman_error("CLAT failed to start periodic prefix query");
 		return -EINVAL;
 	}
@@ -1078,7 +1078,9 @@ static gboolean clat_task_run_dad(gpointer user_data)
 	unsigned char addr[sizeof(struct in6_addr)];
 	int err = 0;
 
-	DBG("");
+	DBG("data %p", data);
+
+	data->dad_id = 0;
 
 	if (inet_pton(AF_INET6, data->address, addr) != 1) {
 		connman_error("failed to pton address %s", data->address);
@@ -1093,7 +1095,11 @@ static gboolean clat_task_run_dad(gpointer user_data)
 		return G_SOURCE_REMOVE;
 	}
 
-	return G_SOURCE_CONTINUE;
+	data->dad_id = g_timeout_add(DAD_TIMEOUT, clat_task_run_dad, data);
+	if (!data->dad_id)
+		connman_error("CLAT failed to start DAD timeout");
+
+	return G_SOURCE_REMOVE;
 }
 
 static int clat_task_start_dad(struct clat_data *data)
@@ -1105,9 +1111,9 @@ static int clat_task_start_dad(struct clat_data *data)
 		return 0;
 	}
 
-	data->dad_id = g_timeout_add(DAD_TIMEOUT, clat_task_run_dad, data);
-
-	if (data->dad_id <= 0) {
+	/* Do DAD initially right away and then with DAD_TIMEOUT interval */
+	data->dad_id = g_timeout_add(0, clat_task_run_dad, data);
+	if (!data->dad_id) {
 		connman_error("CLAT failed to start DAD timeout");
 		return -EINVAL;
 	}
@@ -1119,7 +1125,7 @@ static int clat_task_stop_dad(struct clat_data *data)
 {
 	DBG("");
 
-	if (data->dad_id)
+	if (data->dad_id > 0)
 		g_source_remove(data->dad_id);
 
 	data->dad_id = 0;
@@ -1532,6 +1538,7 @@ static void clat_ipconfig_changed(struct connman_service *service,
 
 	DBG("service %p ipconfig %p", service, ipconfig);
 
+	/* TODO Support WLAN and VPN as well */
 	if (service != data->service || connman_service_get_type(service) !=
 						CONNMAN_SERVICE_TYPE_CELLULAR) {
 		DBG("Not tracking service %p/%s or not cellular", service,
@@ -1661,6 +1668,7 @@ static void clat_service_state_changed(struct connman_service *service,
 	char *ifname;
 	int err;
 
+	// TODO Support also WLAN and VPN
 	if (!service || connman_service_get_type(service) !=
 						CONNMAN_SERVICE_TYPE_CELLULAR)
 		return;

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -68,6 +68,7 @@ struct clat_data {
 	GResolv *resolv;
 	guint resolv_query_id;
 	guint remove_resolv_id;
+	guint resolv_timeouts;
 
 	guint dad_id;
 	guint prefix_query_id;
@@ -96,7 +97,9 @@ struct clat_data {
 #define CLAT_IPv6_METRIC		1024		/* from clatd */
 #define CLAT_IPv6_SUFFIX		"c1a7"
 
-#define PREFIX_QUERY_TIMEOUT		600000		/* 10 seconds */
+#define PREFIX_QUERY_TIMEOUT		600000		/* 10 minutes */
+#define PREFIX_QUERY_RETRY_TIMEOUT	10000		/* 10 seconds */
+#define PREFIX_QUERY_MAX_RETRY_TIMEOUT	6		/* Try 6 times if TO */
 #define DAD_TIMEOUT			600000		/* 10 minutes */
 
 /* Globally defined and assigned prefix */
@@ -677,12 +680,15 @@ static int assign_clat_prefix(struct clat_data *data, char **results)
 	return err;
 }
 
+static int clat_task_start_periodic_query(struct clat_data *data);
+static int clat_task_restart_periodic_query(struct clat_data *data);
+
 static void prefix_query_cb(GResolvResultStatus status,
 					char **results, gpointer user_data)
 {
 	struct clat_data *data = user_data;
 	enum clat_state new_state = data->state;
-	int err;
+	int err = 0;
 
 	DBG("state %d/%s status %d GResolv %p", data->state,
 						state2string(data->state),
@@ -701,21 +707,45 @@ static void prefix_query_cb(GResolvResultStatus status,
 	data->remove_resolv_id = g_timeout_add(0, remove_resolv, data);
 	data->resolv_query_id = 0;
 
-	if (status != G_RESOLV_RESULT_STATUS_SUCCESS) {
-		if (clat_settings.resolv_always_succeeds) {
-			gchar **override = g_new0(char*, 1);
-
-			DBG("ignore resolv result %d", status);
-
-			override[0] = g_strdup("64:ff9b::/96");
-			err = assign_clat_prefix(data, override);
-			g_strfreev(override);
-		} else {
-			err = -EHOSTDOWN;
-		}
-	} else {
+	switch (status) {
+	case G_RESOLV_RESULT_STATUS_SUCCESS:
 		DBG("resolv of %s success, parse prefix", WKN_ADDRESS);
 		err = assign_clat_prefix(data, results);
+		data->resolv_timeouts = 0;
+		break;
+	/* request timeouts not an error, try again */
+	case G_RESOLV_RESULT_STATUS_NO_RESPONSE:
+		err = -ETIMEDOUT;
+		data->resolv_timeouts++;
+		break;
+	/* server had an issue, try again */
+	case G_RESOLV_RESULT_STATUS_SERVER_FAILURE:
+		err = -EHOSTDOWN;
+		break;
+	/* Consider these as non-continuable errors */
+	case G_RESOLV_RESULT_STATUS_ERROR:
+	case G_RESOLV_RESULT_STATUS_FORMAT_ERROR:
+	case G_RESOLV_RESULT_STATUS_NAME_ERROR:
+	case G_RESOLV_RESULT_STATUS_NOT_IMPLEMENTED:
+		err = -EINVAL;
+		break;
+	case G_RESOLV_RESULT_STATUS_REFUSED:
+		err = -ECONNREFUSED;
+		break;
+	case G_RESOLV_RESULT_STATUS_NO_ANSWER:
+		err = -ENOENT;
+		break;
+	}
+
+	if (status != G_RESOLV_RESULT_STATUS_SUCCESS &&
+					clat_settings.resolv_always_succeeds) {
+		gchar **override = g_new0(char*, 1);
+
+		DBG("ignore resolv result %d", status);
+
+		override[0] = g_strdup("64:ff9b::/96");
+		err = assign_clat_prefix(data, override);
+		g_strfreev(override);
 	}
 
 	switch (err) {
@@ -734,17 +764,42 @@ static void prefix_query_cb(GResolvResultStatus status,
 		new_state = CLAT_STATE_RESTART;
 		break;
 	case -EHOSTDOWN:
-		DBG("failed to resolv %s, CLAT is not started", WKN_ADDRESS);
-		if (is_running(data->state))
+		if (is_running(data->state)) {
+			DBG("failed to resolv %s, CLAT is stopped",
+								WKN_ADDRESS);
 			new_state = CLAT_STATE_STOPPED;
+		} else {
+			new_state = CLAT_STATE_FAILURE;
+		}
 
-		/* Go back to idle if doing initial query */
-		if (data->state == CLAT_STATE_PREFIX_QUERY)
-			new_state = CLAT_STATE_IDLE;
+		break;
+	case -ETIMEDOUT:
+		if (data->resolv_timeouts > PREFIX_QUERY_MAX_RETRY_TIMEOUT) {
+			DBG("resolv timeout limit reached, CLAT is stopped");
+			new_state = CLAT_STATE_STOPPED;
+			break;
+		}
+
+		/* Start periodic query if this is the initial query */
+		if (data->state == CLAT_STATE_PREFIX_QUERY) {
+			DBG("failed to resolv %s during initial query, "
+						"continue periodic query",
+						WKN_ADDRESS);
+			clat_task_start_periodic_query(data);
+			return;
+		}
+
+		if (is_running(data->state)) {
+			DBG("query timeouted, retry after %d seconds",
+						PREFIX_QUERY_RETRY_TIMEOUT);
+			clat_task_restart_periodic_query(data);
+		} else {
+			new_state = CLAT_STATE_FAILURE;
+		}
 
 		break;
 	default:
-		DBG("failed to assign prefix, error %d", err);
+		DBG("failed to assign prefix/resolv host, error %d", err);
 		new_state = CLAT_STATE_FAILURE;
 		break;
 	}
@@ -773,13 +828,6 @@ static int clat_task_do_prefix_query(struct clat_data *data)
 {
 	DBG("");
 
-	/*
-	 * TODO handle this
-	 if (connman_inet_check_ipaddress(data->isp_64gateway) > 0) {
-		
-		return -EINVAL;
-	}*/
-
 	if (data->resolv_query_id > 0) {
 		DBG("previous query was running, abort it");
 		remove_resolv(data);
@@ -804,6 +852,17 @@ static int clat_task_do_prefix_query(struct clat_data *data)
 	return 0;
 }
 
+static guint get_pq_timeout(struct clat_data *data)
+{
+	if (!data)
+		return 0;
+
+	if (data->state == CLAT_STATE_PREFIX_QUERY)
+		return PREFIX_QUERY_RETRY_TIMEOUT;
+
+	return PREFIX_QUERY_TIMEOUT;
+}
+
 static gboolean run_prefix_query(gpointer user_data)
 {
 	struct clat_data *data = user_data;
@@ -820,14 +879,31 @@ static gboolean run_prefix_query(gpointer user_data)
 		return G_SOURCE_REMOVE;
 	}
 
-	data->prefix_query_id = g_timeout_add(PREFIX_QUERY_TIMEOUT,
+	data->prefix_query_id = g_timeout_add(get_pq_timeout(data),
 							run_prefix_query, data);
-	if (!data->prefix_query_id) {
+	if (!data->prefix_query_id)
 		connman_error("CLAT failed to continue periodic prefix query");
-		return G_SOURCE_REMOVE;
-	}
 
 	return G_SOURCE_REMOVE;
+}
+
+static int clat_task_restart_periodic_query(struct clat_data *data)
+{
+	DBG("");
+
+	if (data->prefix_query_id > 0) {
+		DBG("Already running, stop old");
+		g_source_remove(data->prefix_query_id);
+	}
+
+	data->prefix_query_id = g_timeout_add(PREFIX_QUERY_RETRY_TIMEOUT,
+							run_prefix_query, data);
+	if (!data->prefix_query_id) {
+		connman_error("CLAT failed to re-start periodic prefix query");
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 static int clat_task_start_periodic_query(struct clat_data *data)
@@ -843,7 +919,7 @@ static int clat_task_start_periodic_query(struct clat_data *data)
 	 * TODO: make this do the queries with AAAA DNS TTL - 10s, i.e., 10s
 	 * before the record expires as stated by RFC.
 	 */
-	data->prefix_query_id = g_timeout_add(PREFIX_QUERY_TIMEOUT,
+	data->prefix_query_id = g_timeout_add(get_pq_timeout(data),
 							run_prefix_query, data);
 	if (!data->prefix_query_id) {
 		connman_error("CLAT failed to start periodic prefix query");
@@ -1411,21 +1487,17 @@ static int clat_run_task(struct clat_data *data)
 	case CLAT_STATE_FAILURE:
 		DBG("CLAT entered failure state, stop all that is running");
 
-		destroy_task(data);
+		stop_running(data);
 
 		/* Do post configure if the interface is up */
 		err = clat_task_post_configure(data);
-		if (err && err != -ENODEV)
+		if (err && err != -ENODEV) {
 			connman_error("CLAT failed to create post-configure "
 						"task in failure state");
+			break;
+		}
 
-		stop_running(data);
-
-		/* Remain in failure state, can be started via clat_start(). */
-		data->state = CLAT_STATE_FAILURE;
-
-		if (err)
-			return err;
+		data->state = CLAT_STATE_POST_CONFIGURE;
 
 		break;
 	}
@@ -1667,7 +1739,8 @@ static int try_clat_start(struct clat_data *data)
 	}
 
 	if (data->ifindex < 0) {
-		DBG("Interface not up, not starting clat");
+		DBG("Interface not up (index %d), not starting clat",
+						data->ifindex);
 		return -ENODEV;
 	}
 
@@ -1714,13 +1787,13 @@ static void clat_ipconfig_changed(struct connman_service *service,
 	if (connman_ipconfig_get_config_type(ipconfig) ==
 						CONNMAN_IPCONFIG_TYPE_IPV4 &&
 						has_ipv4_address(service)) {
-		DBG("cellular/wifi %p has IPv4 config, stop CLAT", service);
+		DBG("cellular %p has IPv4 config, stop CLAT", service);
 		clat_stop(data);
 		return;
 	}
 
 	if (data->service != connman_service_get_default()) {
-		DBG("cellular/wifi service %p is not default, stop CLAT",
+		DBG("cellular service %p is not default, stop CLAT",
 								data->service);
 		clat_stop(data);
 		return;
@@ -1809,7 +1882,7 @@ static void clat_service_state_changed(struct connman_service *service,
 	if (!service || !is_supported_service_type(service))
 		return;
 
-	DBG("cellular/wifi service %p", service);
+	DBG("cellular service %p", service);
 
 	data = get_data();
 

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -28,10 +28,15 @@
 #include <connman/service.h>
 #include <connman/task.h>
 #include <connman/dbus.h>
+/*
+ * TODO this header is included with this change. Change to <connman/nat.h
+ * later after merge...
+ */
 #include "../include/nat.h"
 #include <connman/notifier.h>
 #include <connman/rtnl.h>
 #include <connman/setting.h>
+#include <connman/wakeup_timer.h>
 
 #include <gweb/gresolv.h>
 
@@ -1027,7 +1032,7 @@ static gboolean run_prefix_query(gpointer user_data)
 		return G_SOURCE_REMOVE;
 	}
 
-	data->prefix_query_id = g_timeout_add(get_pq_timeout(data),
+	data->prefix_query_id = connman_wakeup_timer_add(get_pq_timeout(data),
 							run_prefix_query, data);
 	if (!data->prefix_query_id)
 		connman_error("CLAT failed to continue periodic prefix query");
@@ -1044,8 +1049,9 @@ static int clat_task_restart_periodic_query(struct clat_data *data)
 		g_source_remove(data->prefix_query_id);
 	}
 
-	data->prefix_query_id = g_timeout_add(PREFIX_QUERY_RETRY_TIMEOUT,
-							run_prefix_query, data);
+	data->prefix_query_id = connman_wakeup_timer_add(
+						PREFIX_QUERY_RETRY_TIMEOUT,
+						run_prefix_query, data);
 	if (!data->prefix_query_id) {
 		connman_error("CLAT failed to re-start periodic prefix query");
 		return -EINVAL;
@@ -1067,7 +1073,7 @@ static int clat_task_start_periodic_query(struct clat_data *data)
 	 * TODO: make this do the queries with AAAA DNS TTL - 10s, i.e., 10s
 	 * before the record expires as stated by RFC.
 	 */
-	data->prefix_query_id = g_timeout_add(get_pq_timeout(data),
+	data->prefix_query_id = connman_wakeup_timer_add(get_pq_timeout(data),
 							run_prefix_query, data);
 	if (!data->prefix_query_id) {
 		connman_error("CLAT failed to start periodic prefix query");
@@ -1373,7 +1379,8 @@ static gboolean clat_task_run_dad(gpointer user_data)
 		return G_SOURCE_REMOVE;
 	}
 
-	data->dad_id = g_timeout_add(DAD_TIMEOUT, clat_task_run_dad, data);
+	data->dad_id = connman_wakeup_timer_add(DAD_TIMEOUT, clat_task_run_dad,
+									data);
 	if (!data->dad_id)
 		connman_error("CLAT failed to start DAD timeout");
 
@@ -1390,7 +1397,7 @@ static int clat_task_start_dad(struct clat_data *data)
 	}
 
 	/* Do DAD initially right away and then with DAD_TIMEOUT interval */
-	data->dad_id = g_timeout_add(0, clat_task_run_dad, data);
+	data->dad_id = connman_wakeup_timer_add(0, clat_task_run_dad, data);
 	if (!data->dad_id) {
 		connman_error("CLAT failed to start DAD timeout");
 		return -EINVAL;

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -358,6 +358,8 @@ static int force_rmtun(const char *ifname)
 	return 0;
 }
 
+static int clat_stop(struct clat_data *data);
+
 static gboolean io_channel_cb(GIOChannel *source, GIOCondition condition,
 			gpointer user_data)
 {
@@ -443,7 +445,10 @@ static gboolean io_channel_cb(GIOChannel *source, GIOCondition condition,
 				connman_error("Interface lost and failed to "
 							"run CLAT restart %d",
 							err);
-				clat_stop(data);
+				err = clat_stop(data);
+				if (err && err != -EALREADY)
+					connman_error("Stopping CLAT failed %d",
+								err);
 			}
 
 			return G_SOURCE_REMOVE;
@@ -827,6 +832,7 @@ static int assign_clat_prefix(struct clat_data *data, char **results)
 
 static int clat_task_start_periodic_query(struct clat_data *data);
 static int clat_task_restart_periodic_query(struct clat_data *data);
+static int stop_task(struct clat_data *data);
 
 static bool clat_is_running(struct clat_data *data)
 {
@@ -921,16 +927,18 @@ static void prefix_query_cb(GResolvResultStatus status,
 		if (clat_is_running(data)) {
 			DBG("failed to resolv %s, CLAT is stopped",
 								WKN_ADDRESS);
-			new_state = CLAT_STATE_STOPPED;
-		} else {
-			new_state = CLAT_STATE_FAILURE;
+			stop_task(data);
+			return;
 		}
+
+		DBG("failed to resolv %s, set failure state", WKN_ADDRESS);
+		new_state = CLAT_STATE_FAILURE;
 
 		break;
 	case -ETIMEDOUT:
 		if (data->resolv_timeouts > PREFIX_QUERY_MAX_RETRY_TIMEOUT) {
 			DBG("resolv timeout limit reached, CLAT is stopped");
-			new_state = CLAT_STATE_STOPPED;
+			stop_task(data);
 			break;
 		}
 
@@ -947,10 +955,10 @@ static void prefix_query_cb(GResolvResultStatus status,
 			DBG("query timeouted, retry after %d seconds",
 						PREFIX_QUERY_RETRY_TIMEOUT);
 			clat_task_restart_periodic_query(data);
-		} else {
-			new_state = CLAT_STATE_FAILURE;
+			break;
 		}
 
+		new_state = CLAT_STATE_FAILURE;
 		break;
 	default:
 		DBG("failed to assign prefix/resolv host, error %d", err);

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -78,6 +78,7 @@ struct clat_data {
 	GIOChannel *err_ch;
 
 	bool tethering_on;
+	bool do_restart;
 };
 
 #define WKN_ADDRESS "ipv4only.arpa"
@@ -338,7 +339,7 @@ static int create_task(struct clat_data *data)
 	if (!data)
 		return -ENOENT;
 
-	data->task = connman_task_create(clat_settings.tayga_bin, NULL, data);
+	data->task = connman_task_create(clat_settings.tayga_bin, NULL, NULL);
 	if (!data->task)
 		return -ENOMEM;
 
@@ -1003,7 +1004,7 @@ static char *cidr_to_str(unsigned char cidr_netmask)
 	return g_strdup(netmask);
 }
 
-static int clat_task_start_tayga(struct clat_data *data)
+static int clat_task_configure(struct clat_data *data)
 {
 	struct connman_ipconfig *ipconfig;
 	struct connman_ipaddress *ipaddress;
@@ -1237,17 +1238,44 @@ static void clat_task_exit(struct connman_task *task, int exit_code,
 	case CLAT_STATE_PREFIX_QUERY:
 	case CLAT_STATE_PRE_CONFIGURE:
 	case CLAT_STATE_RUNNING:
-		if (exit_code)
-			data->state = CLAT_STATE_FAILURE;
-		else
+		if (exit_code) {
+			/*
+			 * If the process segfaults when clat should be running
+			 * do restart.
+			 */
+			if (data->state == CLAT_STATE_RUNNING)
+				data->state = CLAT_STATE_RESTART;
+			else
+				data->state = CLAT_STATE_FAILURE;
+		} else {
 			DBG("run next state %d/%s", data->state + 1,
 						state2string(data->state + 1));
+		}
 
 		err = clat_run_task(data);
 		if (err && err != -EALREADY)
 			connman_error("failed to run CLAT, error %d", err);
+
 		return;
 	case CLAT_STATE_POST_CONFIGURE:
+		if (data->do_restart) {
+			/*
+			 * RESTART comes after prefix query has been done or
+			 * when the process segfaults, go directly to
+			 * PRE_CONFIGURE state.
+			 */
+			DBG("CLAT process restarting");
+			data->state = CLAT_STATE_PREFIX_QUERY;
+			data->do_restart = false;
+
+			err = clat_run_task(data);
+			if (err && err != -EALREADY)
+				connman_error("failed to run CLAT, error %d",
+									err);
+
+			return;
+		}
+
 		DBG("CLAT process ended");
 		data->state = CLAT_STATE_STOPPED;
 		break;
@@ -1328,7 +1356,7 @@ static int clat_run_task(struct clat_data *data)
 		data->state = CLAT_STATE_PRE_CONFIGURE;
 		break;
 	case CLAT_STATE_PRE_CONFIGURE:
-		err = clat_task_start_tayga(data);
+		err = clat_task_configure(data);
 		if (err) {
 			connman_error("CLAT failed to create run task");
 			break;
@@ -1346,6 +1374,9 @@ static int clat_run_task(struct clat_data *data)
 			connman_warn("CLAT failed to start periodic DAD");
 
 		break;
+	case CLAT_STATE_RESTART:
+		data->do_restart = true;
+		/* fall through */
 	/* If either running or stopped state and run is called do cleanup */
 	case CLAT_STATE_RUNNING:
 	case CLAT_STATE_STOPPED:
@@ -1383,23 +1414,6 @@ static int clat_run_task(struct clat_data *data)
 		if (err)
 			return err;
 
-		break;
-	case CLAT_STATE_RESTART:
-		destroy_task(data);
-
-		/* Run as stopped -> does cleanup */
-		data->state = CLAT_STATE_STOPPED;
-		err = clat_run_task(data);
-		if (err && err != -EALREADY) {
-			connman_error("CLAT failed to start cleanup task");
-			data->state = CLAT_STATE_FAILURE;
-		}
-
-		/*
-		 * RESTART comes after prefix query has been done, go directly
-		 * to PRE_CONFIGURE state.
-		 */
-		data->state = CLAT_STATE_PRE_CONFIGURE;
 		break;
 	}
 
@@ -1487,7 +1501,7 @@ static void clat_new_rtnl_gateway(int index, const char *dst,
 
 	DBG("%d dst %s gateway %s metric %d", index, dst, gateway, metric);
 
-	/* Not the cellular device we are monitoring. */
+	/* Not the device we are monitoring. */
 	if (index != data->ifindex)
 		return;
 
@@ -1536,56 +1550,33 @@ static struct connman_rtnl clat_rtnl = {
 	.delgateway6		= clat_del_rtnl_gateway,
 };
 
-static void clat_ipconfig_changed(struct connman_service *service,
-					struct connman_ipconfig *ipconfig)
+static bool is_supported_service_type(struct connman_service *service)
 {
-	struct connman_network *network;
-	struct clat_data *data = get_data();
-	enum connman_service_state state;
-	int err;
+	enum connman_service_type type;
 
-	if (service || !data->service)
-		return;
+	if (!service)
+		return false;
 
-	DBG("service %p ipconfig %p", service, ipconfig);
+	type = connman_service_get_type(service);
 
-	/* TODO Support WLAN and VPN as well */
-	if (service != data->service || connman_service_get_type(service) !=
-						CONNMAN_SERVICE_TYPE_CELLULAR) {
-		DBG("Not tracking service %p/%s or not cellular", service,
-				connman_service_get_identifier(service));
-		return;
+	switch (type) {
+	case CONNMAN_SERVICE_TYPE_UNKNOWN:
+	case CONNMAN_SERVICE_TYPE_SYSTEM:
+	case CONNMAN_SERVICE_TYPE_ETHERNET:
+	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
+	case CONNMAN_SERVICE_TYPE_GPS:
+	case CONNMAN_SERVICE_TYPE_VPN:
+	case CONNMAN_SERVICE_TYPE_GADGET:
+	case CONNMAN_SERVICE_TYPE_P2P:
+		break;
+	case CONNMAN_SERVICE_TYPE_WIFI:
+		// TODO make this work
+		return false;
+	case CONNMAN_SERVICE_TYPE_CELLULAR:
+		return true;
 	}
 
-	if (connman_ipconfig_get_config_type(ipconfig) ==
-						CONNMAN_IPCONFIG_TYPE_IPV4) {
-		DBG("cellular %p has IPv4 config, stop CLAT", service);
-		clat_stop(data);
-		return;
-	}
-
-	if (service != connman_service_get_default()) {
-		DBG("cellular service %p is not default, stop CLAT", service);
-		clat_stop(data);
-		return;
-	}
-
-	network = connman_service_get_network(service);
-	if (!network || !connman_network_get_connected(network)) {
-		DBG("network %p not connected, stop CLAT", network);
-		clat_stop(data);
-		return;
-	}
-
-	state = connman_service_get_state(service);
-
-	if (state == CONNMAN_SERVICE_STATE_READY ||
-				state == CONNMAN_SERVICE_STATE_ONLINE) {
-		DBG("service %p ready|online, start CLAT", service);
-		err = clat_start(data);
-		if (err && err != -EALREADY)
-			connman_error("CLAT failed to start, error %d", err);
-	}
+	return false;
 }
 
 static bool has_ipv4_address(struct connman_service *service)
@@ -1605,12 +1596,12 @@ static bool has_ipv4_address(struct connman_service *service)
 
 	err = connman_ipaddress_get_ip(ipaddress, &address, &prefixlen);
 	if (err) {
-		DBG("IPv4 is not configured on cellular service %p", service);
+		DBG("IPv4 is not configured on service %p", service);
 		return false;
 	}
 
 	if (!address) {
-		DBG("no IPv4 address on cellular service %p", service);
+		DBG("no IPv4 address on service %p", service);
 		return false;
 	}
 
@@ -1632,25 +1623,149 @@ static bool has_ipv4_address(struct connman_service *service)
 	return true;
 }
 
-static void clat_default_changed(struct connman_service *service)
+static bool is_valid_start_state(enum connman_service_state state)
+{
+	return state == CONNMAN_SERVICE_STATE_READY ||
+				state == CONNMAN_SERVICE_STATE_ONLINE;
+}
+
+static int try_clat_start(struct clat_data *data)
+{
+	struct connman_network *network;
+	char *ifname;
+
+	if (!data || !data->service)
+		return -EINVAL;
+
+	if (!is_valid_start_state(connman_service_get_state(data->service))) {
+		DBG("not ready|online, not starting clat");
+		return -EINVAL;
+	}
+
+	network = connman_service_get_network(data->service);
+	if (!network) {
+		DBG("No network yet, not starting clat");
+		return -ENONET;
+	}
+
+	if (data->ifindex < 0) {
+		DBG("ifindex not set, get it from network");
+		data->ifindex = connman_network_get_index(network);
+	}
+
+	if (data->ifindex < 0) {
+		DBG("Interface not up, not starting clat");
+		return -ENODEV;
+	}
+
+	ifname = connman_inet_ifname(data->ifindex);
+	if (!ifname) {
+		DBG("Interface %d not up, not starting clat", data->ifindex);
+		return -ENODEV;
+	}
+
+	g_free(ifname);
+
+	/* Network may have DHCP/AUTO set without address */
+	if (connman_network_is_configured(network,
+					CONNMAN_IPCONFIG_TYPE_IPV4) &&
+					has_ipv4_address(data->service)) {
+		DBG("Service %p has IPv4 address on interface %d, not "
+						"starting CLAT", data->service,
+						data->ifindex);
+		return 0;
+	}
+
+	return clat_start(data);
+}
+
+static void clat_ipconfig_changed(struct connman_service *service,
+					struct connman_ipconfig *ipconfig)
 {
 	struct connman_network *network;
 	struct clat_data *data = get_data();
+	int err;
 
-	if (!service || !data->service)
+	if (service || !data->service)
+		return;
+
+	DBG("service %p ipconfig %p", service, ipconfig);
+
+	/* TODO Support VPN as well */
+	if (service != data->service || !is_supported_service_type(service)) {
+		DBG("Not tracking service %p/%s or not supported", service,
+				connman_service_get_identifier(service));
+		return;
+	}
+
+	if (connman_ipconfig_get_config_type(ipconfig) ==
+						CONNMAN_IPCONFIG_TYPE_IPV4 &&
+						has_ipv4_address(service)) {
+		DBG("cellular/wifi %p has IPv4 config, stop CLAT", service);
+		clat_stop(data);
+		return;
+	}
+
+	if (data->service != connman_service_get_default()) {
+		DBG("cellular/wifi service %p is not default, stop CLAT",
+								data->service);
+		clat_stop(data);
+		return;
+	}
+
+	network = connman_service_get_network(data->service);
+	if (!network || !connman_network_get_connected(network)) {
+		DBG("network %p not connected, stop CLAT", network);
+		clat_stop(data);
+		return;
+	}
+
+	if (is_valid_start_state(connman_service_get_state(data->service))) {
+		DBG("service %p ready|online, start CLAT", data->service);
+		err = try_clat_start(data);
+		if (err && err != -EALREADY)
+			connman_error("CLAT failed to start, error %d", err);
+	}
+}
+
+static void clat_default_changed(struct connman_service *service)
+{
+	struct connman_network *network;
+	struct clat_data *data;
+	enum connman_service_state state;
+	int err;
+
+	if (!service)
 		return;
 
 	DBG("service %p", service);
 
-	if (!is_running(data->state)) {
-		DBG("CLAT not running, default change not affected");
-		return;
+	data = get_data();
+
+	if (data->service != service) {
+		if (!is_supported_service_type(service)) {
+			DBG("Tracked service %p is not default or valid, "
+								"stop CLAT",
+								data->service);
+			clat_stop(data);
+			return;
+		}
+
+		DBG("Set supported service %p/%s as tracked service", service,
+					connman_service_get_identifier(service));
+		data->service = service;
 	}
 
-	if (data->service && data->service != service) {
-		DBG("Tracked cellular service %p is not default, stop CLAT",
-							data->service);
-		clat_stop(data);
+	state = connman_service_get_state(data->service);
+
+	/* Tracked service is the default service but is not running -> start */
+	if (!is_running(data->state) &&	is_valid_start_state(state)) {
+		DBG("Tracked service is default, start CLAT");
+
+		err = try_clat_start(data);
+		if (err && err != -EALREADY)
+			connman_error("failed to start CLAT %d", err);
+
 		return;
 	}
 
@@ -1664,7 +1779,7 @@ static void clat_default_changed(struct connman_service *service)
 	if (connman_network_is_configured(network,
 					CONNMAN_IPCONFIG_TYPE_IPV4) &&
 					has_ipv4_address(data->service)) {
-		DBG("IPv4 is configured on cellular network %p, stop CLAT",
+		DBG("IPv4 is configured on network %p, stop CLAT",
 							network);
 		clat_stop(data);
 		return;
@@ -1674,17 +1789,16 @@ static void clat_default_changed(struct connman_service *service)
 static void clat_service_state_changed(struct connman_service *service,
 					enum connman_service_state state)
 {
-	struct connman_network *network;
-	struct clat_data *data = get_data();
-	char *ifname;
+	struct clat_data *data;
 	int err;
 
 	// TODO Support also WLAN and VPN
-	if (!service || connman_service_get_type(service) !=
-						CONNMAN_SERVICE_TYPE_CELLULAR)
+	if (!service || !is_supported_service_type(service))
 		return;
 
-	DBG("cellular service %p", service);
+	DBG("cellular/wifi service %p", service);
+
+	data = get_data();
 
 	switch (state) {
 	/* Not connected */
@@ -1741,43 +1855,10 @@ static void clat_service_state_changed(struct connman_service *service,
 		goto onlinecheck;
 	}
 
-	network = connman_service_get_network(service);
-	if (!network) {
-		DBG("No network yet, not starting clat");
-		return;
+	err = try_clat_start(data);
+	if (err && err != -EALREADY) {
+		connman_error("CLAT failed to start");
 	}
-
-	if (data->ifindex < 0) {
-		DBG("ifindex not set, get it from network");
-		data->ifindex = connman_network_get_index(network);
-	}
-
-	if (data->ifindex < 0) {
-		DBG("Interface not up, not starting clat");
-		return;
-	}
-
-	ifname = connman_inet_ifname(data->ifindex);
-	if (!ifname) {
-		DBG("Interface %d not up, not starting clat", data->ifindex);
-		return;
-	}
-
-	g_free(ifname);
-
-	/* Network may have DHCP/AUTO set without address */
-	if (connman_network_is_configured(network,
-					CONNMAN_IPCONFIG_TYPE_IPV4) &&
-					has_ipv4_address(data->service)) {
-		DBG("Service %p has IPv4 address on interface %d, not "
-						"starting CLAT", data->service,
-						data->ifindex);
-		return;
-	}
-
-	err = clat_start(data);
-	if (err && err != -EALREADY)
-		connman_error("failed to start CLAT, error %d", err);
 
 onlinecheck:
 	if (state == CONNMAN_SERVICE_STATE_ONLINE &&

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -39,8 +39,6 @@
 
 #define CONNMAN_API_SUBJECT_TO_CHANGE
 
-#define WKN_ADDRESS "ipv4only.arpa"
-
 enum clat_state {
 	CLAT_STATE_IDLE = 0,
 	CLAT_STATE_PREFIX_QUERY,
@@ -82,21 +80,25 @@ struct clat_data {
 	bool tethering_on;
 };
 
-#define DEFAULT_TAYGA_BIN		"/usr/local/bin/tayga"
+#define WKN_ADDRESS "ipv4only.arpa"
+#define DEFAULT_TAYGA_BIN		"/usr/sbin/tayga"
 #define TAYGA_CLAT_DEVICE		"clat"
 #define TAYGA_CONF			"tayga.conf"
 #define TAYGA_IPv4ADDR			"192.0.0.2"	/* from RFC 7335 */
+
 #define CLAT_IPv4ADDR			"192.0.0.1"	/* from RFC 7335 */
-#define IPv4ADDR_NETMASK		29		/* from RFC 7335 */
-#define CLAT_INADDR_ANY		"0.0.0.0"
+#define CLAT_IPv4ADDR_NETWORK		"192.0.0.0"	/* from RFC 7335 */
+#define CLAT_IPv4ADDR_NETMASK		29		/* from RFC 7335 */
+#define CLAT_IPv4_INADDR_ANY		"0.0.0.0"
 #define CLAT_IPv4_METRIC		2049		/* Set as value -1 */
 #define CLAT_IPv4_ROUTE_MTU		1260		/* from clatd */
-#define CLAT_IPv6_METRIC		1024
-#define CLAT_SUFFIX			"c1a7"
+#define CLAT_IPv6_METRIC		1024		/* from clatd */
+#define CLAT_IPv6_SUFFIX		"c1a7"
 
 #define PREFIX_QUERY_TIMEOUT		600000		/* 10 seconds */
 #define DAD_TIMEOUT			600000		/* 10 minutes */
 
+/* Globally defined and assigned prefix */
 static const char GLOBAL_PREFIX[] = "64:ff9b::";
 static const unsigned char GLOBAL_PREFIXLEN = 96;
 
@@ -110,19 +112,19 @@ static struct {
 } clat_settings = {
 	.tayga_bin = NULL,
 
-	/* Use DAD for protecting the address, in android this is done */
+	/* Use DAD for protecting the address, default to being on. */
 	.dad_enabled = true,
 
-	/* Resolv result always sets global prefix if fails */
+	/* Resolv result always sets global prefix if fails, default off */
 	.resolv_always_succeeds = false,
 
-	/* Add netmask to the CLAT device IPv4 address */
+	/* Add netmask to the CLAT device IPv4 address, default on */
 	.clat_device_use_netmask = true,
 
-	/* Write IPv6 address of the interface used to the tayga config */
+	/* Write IPv6 address of the interface to tayga config, default off */
 	.tayga_use_ipv6_conf = false,
 
-	/* Value for strict-frag-hdr, defaults on */
+	/* Value for strict-frag-hdr, default on */
 	.tayga_use_strict_frag_hdr = true,
 };
 
@@ -180,6 +182,8 @@ static void parse_clat_config(GKeyFile *config)
 		clat_settings.tayga_bin = g_strdup(str);
 	else
 		clat_settings.tayga_bin = g_strdup(DEFAULT_TAYGA_BIN);
+
+	g_clear_error(&error);
 
 	boolean = g_key_file_get_boolean(config, group, CONF_DAD_ENABLED,
 						&error);
@@ -463,7 +467,7 @@ static int clat_create_tayga_config(struct clat_data *data)
 	g_string_append_printf(str, "map %s %s\n", CLAT_IPv4ADDR,
 						data->address);
 
-	/* ippool.c apparently defaults to 24 subnet */
+	/* ippool.c apparently defaults to 24 subnet for tethering */
 	g_string_append_printf(str, "dynamic-pool %s/%u\n",
 				connman_setting_get_string(
 					"TetheringSubnetBlock"),
@@ -556,6 +560,7 @@ static struct prefix_entry *new_prefix_entry(const char *address)
 		entry->prefix = g_strdup(tokens[0]);
 		entry->prefixlen = (unsigned char)g_ascii_strtoull(tokens[1],
 								NULL, 10);
+	/* TODO create proper parser for addresses without prefix */
 	} else {
 		DBG("address does not contain a valid prefix");
 		free_prefix_entry(entry);
@@ -693,8 +698,10 @@ static void prefix_query_cb(GResolvResultStatus status,
 
 	if (status != G_RESOLV_RESULT_STATUS_SUCCESS) {
 		if (clat_settings.resolv_always_succeeds) {
-			DBG("ignore resolv result %d", status);
 			gchar **override = g_new0(char*, 1);
+
+			DBG("ignore resolv result %d", status);
+
 			override[0] = g_strdup("64:ff9b::/96");
 			err = assign_clat_prefix(data, override);
 			g_strfreev(override);
@@ -723,7 +730,13 @@ static void prefix_query_cb(GResolvResultStatus status,
 		break;
 	case -EHOSTDOWN:
 		DBG("failed to resolv %s, CLAT is not started", WKN_ADDRESS);
-		new_state = CLAT_STATE_STOPPED;
+		if (is_running(data->state))
+			new_state = CLAT_STATE_STOPPED;
+
+		/* Go back to idle if doing initial query */
+		if (data->state == CLAT_STATE_PREFIX_QUERY)
+			new_state = CLAT_STATE_IDLE;
+
 		break;
 	default:
 		DBG("failed to assign prefix, error %d", err);
@@ -812,6 +825,10 @@ static int clat_task_start_periodic_query(struct clat_data *data)
 		return -EALREADY;
 	}
 
+	/*
+	 * TODO: make this do the queries with AAAA DNS TTL - 10s, i.e., 10s
+	 * before the record expires as stated by RFC.
+	 */
 	data->prefix_query_id = g_timeout_add(PREFIX_QUERY_TIMEOUT,
 							run_prefix_query, data);
 	if (!data->prefix_query_id) {
@@ -892,7 +909,7 @@ static int derive_ipv6_address(struct clat_data *data, const char *ipv6_addr,
 	 * https://github.com/toreanderson/clatd/blob/master/clatd#L442
 	 * 
 	 */
-	data->address = g_strconcat(ipv6prefix, "::", CLAT_SUFFIX, NULL);
+	data->address = g_strconcat(ipv6prefix, "::", CLAT_IPv6_SUFFIX, NULL);
 	data->addr_prefixlen = 128;
 
 	return 0;
@@ -1031,7 +1048,7 @@ static int clat_task_start_tayga(struct clat_data *data)
 						CLAT_IPv6_METRIC);
 	//$ ip address add 192.0.0.2 dev clat
 	if (clat_settings.clat_device_use_netmask)
-		netmask = cidr_to_str(IPv4ADDR_NETMASK);
+		netmask = cidr_to_str(CLAT_IPv4ADDR_NETMASK);
 
 	ipaddress = connman_ipaddress_alloc(AF_INET);
 	connman_ipaddress_set_ipv4(ipaddress, CLAT_IPv4ADDR, netmask, NULL);
@@ -1039,9 +1056,9 @@ static int clat_task_start_tayga(struct clat_data *data)
 
 	//$ ip -4 route add default dev clat
 	/* Set no address, all traffic should be forwarded to the device */
-	connman_inet_add_network_route_with_metric(index, CLAT_INADDR_ANY,
-							CLAT_INADDR_ANY,
-							CLAT_INADDR_ANY,
+	connman_inet_add_network_route_with_metric(index, CLAT_IPv4_INADDR_ANY,
+							CLAT_IPv4_INADDR_ANY,
+							CLAT_IPv4_INADDR_ANY,
 							CLAT_IPv4_METRIC,
 							CLAT_IPv4_ROUTE_MTU);
 	connman_ipaddress_free(ipaddress);
@@ -1140,9 +1157,6 @@ static int clat_task_post_configure(struct clat_data *data)
 	char *netmask = NULL;
 	int index;
 
-	//$ ip link set dev clat up
-	// TODO wait for rtnl notify?
-
 	ipconfig = connman_service_get_ipconfig(data->service, AF_INET6);
 	if (ipconfig)
 		connman_nat6_restore(ipconfig, data->address,
@@ -1151,28 +1165,29 @@ static int clat_task_post_configure(struct clat_data *data)
 	DBG("ipconfig %p", ipconfig);
 
 	index = connman_inet_ifindex(TAYGA_CLAT_DEVICE);
-	if (index >= 0) {
-		ipaddress = connman_ipaddress_alloc(AF_INET);
-		connman_inet_del_network_route_with_metric(index, CLAT_IPv4ADDR,
-							CLAT_IPv4_METRIC);
-
-		if (clat_settings.clat_device_use_netmask)
-			netmask = cidr_to_str(IPv4ADDR_NETMASK);
-
-		connman_ipaddress_set_ipv4(ipaddress, CLAT_IPv4ADDR, netmask,
-							NULL);
-		g_free(netmask);
-
-		connman_inet_clear_address(index, ipaddress);
-		connman_inet_del_ipv6_network_route_with_metric(index,
-							data->address,
-							data->addr_prefixlen,
-							CLAT_IPv6_METRIC);
-		connman_inet_ifdown(index);
-		connman_ipaddress_free(ipaddress);
-	} else {
+	if (index < 0) {
 		DBG("CLAT tayga interface not up, nothing to do");
+		return -ENODEV;
 	}
+
+	ipaddress = connman_ipaddress_alloc(AF_INET);
+	connman_inet_del_network_route_with_metric(index, CLAT_IPv4ADDR,
+						CLAT_IPv4_METRIC);
+
+	if (clat_settings.clat_device_use_netmask)
+		netmask = cidr_to_str(CLAT_IPv4ADDR_NETMASK);
+
+	connman_ipaddress_set_ipv4(ipaddress, CLAT_IPv4ADDR, netmask,
+						NULL);
+	g_free(netmask);
+
+	connman_inet_clear_address(index, ipaddress);
+	connman_inet_del_ipv6_network_route_with_metric(index,
+						data->address,
+						data->addr_prefixlen,
+						CLAT_IPv6_METRIC);
+	connman_inet_ifdown(index);
+	connman_ipaddress_free(ipaddress);
 
 	if (create_task(data))
 		return -ENOMEM;
@@ -1200,7 +1215,7 @@ static void clat_task_exit(struct connman_task *task, int exit_code,
 		return;
 	}
 
-	DBG("state %d/%s", data->state, state2string(data->state));
+	DBG("task %p state %d/%s", task, data->state, state2string(data->state));
 
 	if (exit_code)
 		connman_warn("CLAT task failed with code %d", exit_code);
@@ -1259,7 +1274,8 @@ static void setup_double_nat(struct clat_data *data)
 		DBG("tethering enabled when CLAT is running, override nat");
 
 		err = connman_nat_enable_double_nat_override(TAYGA_CLAT_DEVICE,
-						"192.0.0.0", IPv4ADDR_NETMASK);
+						CLAT_IPv4ADDR_NETWORK,
+						CLAT_IPv4ADDR_NETMASK);
 		if (err && err != -EINPROGRESS)
 			connman_error("Failed to setup double nat for tether");
 	} else {
@@ -1440,33 +1456,28 @@ static int clat_start(struct clat_data *data)
 
 static int clat_stop(struct clat_data *data)
 {
-	int err;
-
 	if (!data)
 		return -EINVAL;
 
 	DBG("state %d/%s", data->state, state2string(data->state));
 
-	destroy_task(data);
-
-	/* Run as stopped -> does cleanup */
-	data->state = CLAT_STATE_STOPPED;
-	err = clat_run_task(data);
-	if (err && err != -EALREADY) {
-		connman_error("CLAT failed to start cleanup task");
-		data->state = CLAT_STATE_FAILURE;
+	if (!is_running(data->state)) {
+		DBG("already stopping/stopped");
+		return -EALREADY;
 	}
 
-	/* Sets as idle */
-	clat_data_clear(data);
+	if (data->task)
+		connman_task_stop(data->task);
+	else
+		data->state = CLAT_STATE_STOPPED;
 
-	return err;
-}
-
-static int clat_failure(struct clat_data *data)
-{
 	return 0;
 }
+
+/*static int clat_failure(struct clat_data *data)
+{
+	return 0;
+}*/
 
 static void clat_new_rtnl_gateway(int index, const char *dst,
 						const char *gateway, int metric,
@@ -1808,6 +1819,8 @@ static int clat_init(void)
 	if (config) {
 		parse_clat_config(config);
 		g_key_file_free(config);
+	} else {
+		clat_settings.tayga_bin = g_strdup(DEFAULT_TAYGA_BIN);
 	}
 
 	__data = clat_data_init();
@@ -1837,8 +1850,7 @@ static void clat_exit(void)
 {
 	DBG("");
 
-	if (is_running(__data->state))
-		clat_stop(__data);
+	clat_stop(__data);
 
 	connman_notifier_unregister(&clat_notifier);
 	connman_rtnl_handle_rtprot_ra(false);

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -1,0 +1,1760 @@
+/*
+ *  Connection Manager
+ *
+ *  Copyright (C) 2023 Jolla Ltd. All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <errno.h>
+
+#include <connman/ipconfig.h>
+#include <connman/inet.h>
+#include <connman/log.h>
+#include <connman/network.h>
+#include <connman/plugin.h>
+#include <connman/service.h>
+#include <connman/task.h>
+#include <connman/dbus.h>
+#include "../include/nat.h"
+#include <connman/notifier.h>
+#include <connman/rtnl.h>
+
+#include <gweb/gresolv.h>
+
+#include <glib.h>
+
+#define CONNMAN_API_SUBJECT_TO_CHANGE
+
+#define WKN_ADDRESS "ipv4only.arpa"
+
+enum clat_state {
+	CLAT_STATE_IDLE = 0,
+	CLAT_STATE_PREFIX_QUERY,
+	CLAT_STATE_PRE_CONFIGURE,
+	CLAT_STATE_RUNNING,
+	CLAT_STATE_POST_CONFIGURE,
+	CLAT_STATE_STOPPED, // TODO: killed?
+	CLAT_STATE_FAILURE,
+	CLAT_STATE_RESTART,
+};
+
+struct clat_data {
+	struct connman_service *service;
+	struct connman_task *task;
+	enum clat_state state;
+	char *isp_64gateway;
+
+	char *config_path;
+	char *clat_prefix;
+	char *address;
+	char *ipv6address;
+	unsigned char clat_prefixlen;
+	unsigned char addr_prefixlen;
+	unsigned char ipv6_prefixlen;
+	int ifindex;
+
+	GResolv *resolv;
+	guint resolv_query_id;
+	guint remove_resolv_id;
+
+	guint dad_id;
+	guint prefix_query_id;
+
+	int out_ch_id;
+	int err_ch_id;
+	GIOChannel *out_ch;
+	GIOChannel *err_ch;
+};
+
+#define DEFAULT_TAYGA_BIN		"/usr/local/bin/tayga"
+#define TAYGA_CLAT_DEVICE		"clat"
+#define TAYGA_CONF			"tayga.conf"
+#define TAYGA_IPv4ADDR			"192.0.0.2"	/* from RFC 7335 */
+#define CLAT_IPv4ADDR			"192.0.0.1"	/* from RFC 7335 */
+#define IPv4ADDR_NETMASK		29		/* from RFC 7335 */
+#define CLAT_INADDR_ANY		"0.0.0.0"
+#define CLAT_IPv4_METRIC		2049		/* Set as value -1 */
+#define CLAT_IPv6_METRIC		1024
+#define CLAT_SUFFIX			"c1a7"
+
+#define PREFIX_DAD_TIMEOUT		10000		/* 10 seconds */
+#define DAD_TIMEOUT			600000		/* 10 minutes */
+
+static const char GLOBAL_PREFIX[] = "64:ff9b::";
+static const unsigned char GLOBAL_PREFIXLEN = 96;
+
+static struct {
+	char *tayga_bin;
+	bool dad_enabled;
+	bool resolv_always_succeeds;
+	bool clat_device_use_netmask;
+	bool tayga_use_ipv6_conf;
+} clat_settings = {
+	.tayga_bin = NULL,
+
+	/* Use DAD for protecting the address, in android this is done */
+	.dad_enabled = true,
+
+	/* Resolv result always sets global prefix if fails */
+	.resolv_always_succeeds = false,
+
+	/* Add netmask to the CLAT device IPv4 address */
+	.clat_device_use_netmask = false,
+
+	/* Write IPv6 address of the interface used to the tayga config */
+	.tayga_use_ipv6_conf = false,
+};
+
+#define CLATCONFIGFILE			CONFIGDIR "/clat.conf"
+#define CONF_TAYGA_BIN			"Tayga"
+#define CONF_DAD_ENABLED		"EnableDAD"
+#define CONF_RESOLV_ALWAYS_SUCCEEDS	"ResolvAlwaysSucceeds"
+#define CONF_CLAT_USE_NETMASK		"ClatDeviceUseNetmask"
+#define CONF_TAYGA_USE_IPV6_CONF	"TaygaRequiresIPv6Address"
+
+struct clat_data *__data = NULL;
+
+static GKeyFile *load_clat_config(const char *file)
+{
+	GError *err = NULL;
+	GKeyFile *keyfile;
+
+	keyfile = g_key_file_new();
+
+	g_key_file_set_list_separator(keyfile, ',');
+
+	if (!g_key_file_load_from_file(keyfile, file, 0, &err)) {
+		if (err->code != G_FILE_ERROR_NOENT) {
+			connman_error("Parsing %s failed: %s", file,
+								err->message);
+		}
+
+		g_error_free(err);
+		g_key_file_unref(keyfile);
+		return NULL;
+	}
+
+	DBG("load config %s", file);
+
+	return keyfile;
+}
+
+static void parse_clat_config(GKeyFile *config)
+{
+	GError *error = NULL;
+	bool boolean;
+	char *str;
+	const char *group = "CLAT";
+
+	if (!config) {
+		DBG("No CLAT config was found, nothing to parse");
+		return;
+	}
+
+	DBG("parsing config %p", config);
+
+	str = g_key_file_get_string(config, group, CONF_TAYGA_BIN, &error);
+	if (!error)
+		clat_settings.tayga_bin = g_strdup(str);
+	else
+		clat_settings.tayga_bin = g_strdup(DEFAULT_TAYGA_BIN);
+
+	boolean = g_key_file_get_boolean(config, group, CONF_DAD_ENABLED,
+						&error);
+	if (!error)
+		clat_settings.dad_enabled = boolean;
+
+	g_clear_error(&error);
+
+	boolean = g_key_file_get_boolean(config, group,
+						CONF_RESOLV_ALWAYS_SUCCEEDS,
+						&error);
+	if (!error)
+		clat_settings.resolv_always_succeeds = boolean;
+
+	g_clear_error(&error);
+
+	boolean = g_key_file_get_boolean(config, group,
+						CONF_CLAT_USE_NETMASK,
+						&error);
+	if (!error)
+		clat_settings.clat_device_use_netmask = boolean;
+
+	g_clear_error(&error);
+
+	boolean = g_key_file_get_boolean(config, group,
+						CONF_TAYGA_USE_IPV6_CONF,
+						&error);
+	if (!error)
+		clat_settings.tayga_use_ipv6_conf = boolean;
+
+	g_clear_error(&error);
+}
+
+static void clear_clat_config(void)
+{
+	g_free(clat_settings.tayga_bin);
+}
+
+static bool is_running(enum clat_state state)
+{
+	switch (state) {
+	case CLAT_STATE_IDLE:
+	case CLAT_STATE_STOPPED:
+	case CLAT_STATE_FAILURE:
+		return false;
+	case CLAT_STATE_PREFIX_QUERY:
+	case CLAT_STATE_PRE_CONFIGURE:
+	case CLAT_STATE_RUNNING:
+	case CLAT_STATE_POST_CONFIGURE:
+	case CLAT_STATE_RESTART:
+		return true;
+	}
+
+	return false;
+}
+
+static const char* state2string(enum clat_state state)
+{
+	switch (state) {
+	case CLAT_STATE_IDLE:
+		return "idle";
+	case CLAT_STATE_STOPPED:
+		return "stopped";
+	case CLAT_STATE_FAILURE:
+		return "failure";
+	case CLAT_STATE_PREFIX_QUERY:
+		return "prefix query";
+	case CLAT_STATE_PRE_CONFIGURE:
+		return "pre configure";
+	case CLAT_STATE_RUNNING:
+		return "running";
+	case CLAT_STATE_POST_CONFIGURE:
+		return "post configure";
+	case CLAT_STATE_RESTART:
+		return "restart";
+	}
+
+	return "invalid state";
+}
+
+static void close_io_channel(struct clat_data *data, GIOChannel *channel)
+{
+	if (!data || !channel)
+		return;
+
+	if (data->out_ch == channel) {
+		DBG("closing task %p STDOUT", data->task);
+
+		if (data->out_ch_id) {
+			g_source_remove(data->out_ch_id);
+			data->out_ch_id = 0;
+		}
+
+		g_io_channel_shutdown(data->out_ch, FALSE, NULL);
+		g_io_channel_unref(data->out_ch);
+
+		data->out_ch = NULL;
+		return;
+	}
+
+	if (data->err_ch == channel) {
+		DBG("closing task %p STDERR", data->task);
+
+		if (data->err_ch_id) {
+			g_source_remove(data->err_ch_id);
+			data->err_ch_id = 0;
+		}
+
+		g_io_channel_shutdown(data->err_ch, FALSE, NULL);
+		g_io_channel_unref(data->err_ch);
+
+		data->err_ch = NULL;
+		return;
+	}
+}
+
+static gboolean io_channel_cb(GIOChannel *source, GIOCondition condition,
+			gpointer user_data)
+{
+	struct clat_data *data = user_data;
+	char *str;
+	const char *type = (source == data->out_ch ? "STDOUT" :
+				(source == data->err_ch ? "STDERR" : "NaN"));
+
+	if ((condition & G_IO_IN) &&
+		g_io_channel_read_line(source, &str, NULL, NULL, NULL) ==
+							G_IO_STATUS_NORMAL) {
+		str[strlen(str) - 1] = '\0';
+
+		connman_error("CLAT %s: %s", clat_settings.tayga_bin, str);
+
+		g_free(str);
+	} else if (condition & (G_IO_ERR | G_IO_HUP)) {
+		DBG("%s Channel termination", type);
+		close_io_channel(data, source);
+		return G_SOURCE_REMOVE;
+	}
+
+	return G_SOURCE_CONTINUE;
+}
+
+static int create_task(struct clat_data *data)
+{
+	if (!data)
+		return -ENOENT;
+
+	data->task = connman_task_create(clat_settings.tayga_bin, NULL, data);
+	if (!data->task)
+		return -ENOMEM;
+
+	DBG("task %p", data->task);
+
+	return 0;
+}
+
+static int destroy_task(struct clat_data *data)
+{
+	int err;
+
+	if (!data || !data->task)
+		return -ENOENT;
+
+	DBG("task %p", data->task);
+
+	err = connman_task_stop(data->task);
+	if (err) {
+		connman_error("CLAT failed to stop current task");
+		return err;
+	}
+
+	connman_task_destroy(data->task);
+	data->task = NULL;
+	return 0;
+}
+
+static struct clat_data *get_data()
+{
+	return __data;
+}
+
+static void clat_data_clear(struct clat_data *data)
+{
+	if (!data)
+		return;
+
+	DBG("data %p", data);
+
+	destroy_task(data);
+
+	g_free(data->isp_64gateway);
+	data->isp_64gateway = NULL;
+
+	g_free(data->config_path);
+	data->config_path = NULL;
+
+	g_free(data->clat_prefix);
+	data->clat_prefix = NULL;
+
+	g_free(data->address);
+	data->address = NULL;
+
+	g_free(data->ipv6address);
+	data->ipv6address = NULL;
+
+	data->clat_prefixlen = 0;
+	data->addr_prefixlen = 0;
+	data->ipv6_prefixlen = 0;
+	data->ifindex = -1;
+
+	data->state = CLAT_STATE_IDLE;
+}
+
+static void clat_data_free(struct clat_data *data)
+{
+	DBG("");
+
+	if (!data)
+		return;
+
+	clat_data_clear(data);
+	g_free(data);
+}
+
+static struct clat_data *clat_data_init()
+{
+	struct clat_data *data;
+
+	DBG("");
+
+	data = g_new0(struct clat_data, 1);
+	if (!data)
+		return NULL;
+
+	data->ifindex = -1;
+
+	return data;
+}
+
+static int clat_create_tayga_config(struct clat_data *data)
+{
+	GError *error = NULL;
+	GString *str;
+	char *buf;
+	int err;
+
+	g_free(data->config_path);
+	data->config_path = g_build_filename(RUNSTATEDIR, "connman",
+						TAYGA_CONF, NULL);
+
+	DBG("config %s", data->config_path);
+
+	str = g_string_new("");
+
+	g_string_append_printf(str, "tun-device %s\n", TAYGA_CLAT_DEVICE);
+	g_string_append_printf(str, "ipv4-addr %s\n", TAYGA_IPv4ADDR);
+
+	/* IPv6 address is required only when global prefix is in use */
+	if (clat_settings.tayga_use_ipv6_conf)
+		g_string_append_printf(str, "ipv6-addr %s\n",
+							data->ipv6address);
+
+	g_string_append_printf(str, "prefix %s/%u\n", data->clat_prefix,
+						data->clat_prefixlen);
+
+	/*
+	 * Man pages state that:
+	 * Creates  a static mapping between RFC 7577 compliant hosts or
+	 * subnets ipv4_address[/length] and ipv6_address[/length] to be used
+	 * when translating IPv4 packets to IPv6 or IPv6 packets to IPv4. If
+	 * /length is not present, the /length after ipv4_address is treated
+	 * as "/32" and that of ipv6_address as "/128".
+	 *
+	 * BUT IT DOES NOT WORK.
+	 */
+	g_string_append_printf(str, "map %s %s\n", CLAT_IPv4ADDR,
+						data->address);
+
+	buf = g_string_free(str, FALSE);
+
+	g_file_set_contents(data->config_path, buf, -1, &error);
+	if (error) {
+		connman_error("Error creating conf: %s\n", error->message);
+		g_error_free(error);
+		err = -EIO;
+	}
+
+	g_free(buf);
+
+	return err;
+}
+
+static int clat_run_task(struct clat_data *data);
+
+static gboolean remove_resolv(gpointer user_data)
+{
+	struct clat_data *data = user_data;
+
+	DBG("");
+
+	if (data->remove_resolv_id)
+		g_source_remove(data->remove_resolv_id);
+
+	if (data->resolv && data->resolv_query_id) {
+		DBG("cancel resolv lookup");
+		g_resolv_cancel_lookup(data->resolv, data->resolv_query_id);
+	}
+
+	data->resolv_query_id = 0;
+	data->remove_resolv_id = 0;
+
+	g_resolv_unref(data->resolv);
+	data->resolv = NULL;
+
+	return G_SOURCE_REMOVE;
+}
+
+struct prefix_entry {
+	char *prefix;
+	unsigned char prefixlen;
+};
+
+static void free_prefix_entry(gpointer user_data)
+{
+	struct prefix_entry *entry = user_data;
+
+	DBG("entry %p", entry);
+
+	if (!entry)
+		return;
+
+	g_free(entry->prefix);
+	g_free(entry);
+}
+
+static struct prefix_entry *new_prefix_entry(const char *address)
+{
+	struct prefix_entry *entry;
+	gchar **tokens;
+
+	DBG("address %s", address);
+
+	if (!address)
+		return NULL;
+
+	tokens = g_strsplit(address, "/", 2);
+	entry = g_new0(struct prefix_entry, 1);
+	if (!entry)
+		return NULL;
+
+	DBG("entry %p", entry);
+
+	/* Result has a global prefix */
+	if (g_str_has_prefix(address, GLOBAL_PREFIX)) {
+		entry->prefix = g_strdup(GLOBAL_PREFIX);
+		entry->prefixlen = GLOBAL_PREFIXLEN;
+	/* Result had address and prefix length. */
+	} else if (tokens && g_strv_length(tokens) == 2) {
+		entry->prefix = g_strdup(tokens[0]);
+		entry->prefixlen = (unsigned char)g_ascii_strtoull(tokens[1],
+								NULL, 10);
+	} else {
+		DBG("address does not contain a valid prefix");
+		free_prefix_entry(entry);
+		return NULL;
+	}
+	/*
+	 * TODO: Check the prefixlenght from other than ones with GLOBAL_PREFIX
+	 * utilizing XOR of the A record result. Use /96 prefix for all as
+	 * android does.
+	 */
+
+	if (tokens)
+		g_strfreev(tokens);
+
+	if (entry->prefixlen > 128 || entry->prefixlen < 16) {
+		DBG("Invalid prefixlen %u", entry->prefixlen);
+		g_free(entry);
+		return NULL;
+	}
+
+	DBG("prefix %s/%u", entry->prefix, entry->prefixlen);
+
+	return entry;
+}
+
+static gint prefix_comp(gconstpointer a, gconstpointer b)
+{
+	const struct prefix_entry *entry_a = a;
+	const struct prefix_entry *entry_b = b;
+
+	/* Largest on top */
+	if (entry_a->prefixlen > entry_b->prefixlen)
+		return -1;
+
+	if (entry_a->prefixlen < entry_b->prefixlen)
+		return 1;
+
+	return 0;
+}
+
+static int assign_clat_prefix(struct clat_data *data, char **results)
+{
+	GList *prefixes = NULL;
+	GList *first;
+	struct prefix_entry *entry;
+	int err = 0;
+	int len;
+	int i;
+
+	if (!results) {
+		DBG("no results");
+		return -ENOENT;
+	}
+
+	len = g_strv_length(results);
+	DBG("got %d results", len);
+
+	for (i = 0; i < len; i++) {
+		entry = new_prefix_entry(results[i]);
+		if (!entry)
+			continue;
+
+		prefixes = g_list_insert_sorted(prefixes, entry, prefix_comp);
+	}
+
+	first = g_list_first(prefixes);
+	if (!first || !(entry = first->data)) {
+		DBG("no prefixes found, fallback using global %s/%u",
+							GLOBAL_PREFIX,
+							GLOBAL_PREFIXLEN);
+		entry = new_prefix_entry(GLOBAL_PREFIX);
+		prefixes = g_list_insert_sorted(prefixes, entry, prefix_comp);
+	}
+
+	if (!entry) {
+		DBG("no entry is set");
+		g_list_free_full(prefixes, free_prefix_entry);
+		return -ENOENT;
+	}
+
+	/* A prefix exists already */
+	if (data->clat_prefix) {
+		if (g_strcmp0(data->clat_prefix, entry->prefix) &&
+				data->clat_prefixlen != entry->prefixlen) {
+			DBG("changing existing prefix %s/%u -> %s/%u",
+						data->clat_prefix,
+						data->clat_prefixlen,
+						entry->prefix,
+						entry->prefixlen);
+			err = -ERESTART;
+		}
+
+		if (!g_strcmp0(data->clat_prefix, entry->prefix) &&
+				data->clat_prefixlen == entry->prefixlen) {
+			DBG("no change to existing prefix %s/%u",
+						data->clat_prefix,
+						data->clat_prefixlen);
+			err = -EALREADY;
+		}
+	}
+
+
+	g_free(data->clat_prefix);
+	data->clat_prefix = g_strdup(entry->prefix);
+	data->clat_prefixlen = entry->prefixlen;
+
+	g_list_free_full(prefixes, free_prefix_entry);
+
+	return err;
+}
+
+static void prefix_query_cb(GResolvResultStatus status,
+					char **results, gpointer user_data)
+{
+	struct clat_data *data = user_data;
+	enum clat_state new_state = data->state;
+	int err;
+
+	DBG("state %d/%s status %d GResolv %p", data->state,
+						state2string(data->state),
+						status, data->resolv);
+
+	if (!data->resolv && !data->resolv_query_id) {
+		DBG("resolv was already cleared, running state: %s",
+					is_running(data->state) ? "yes" : "no");
+		return;
+	}
+
+	/*
+	 * We cannot unref the resolver here as resolv struct is manipulated
+	 * by gresolv.c after we return from this callback.
+	 */
+	data->remove_resolv_id = g_timeout_add(0, remove_resolv, data);
+	data->resolv_query_id = 0;
+
+	if (status != G_RESOLV_RESULT_STATUS_SUCCESS) {
+		if (clat_settings.resolv_always_succeeds) {
+			DBG("ignore resolv result %d", status);
+			gchar **override = g_new0(char*, 1);
+			override[0] = g_strdup("64:ff9b::/96");
+			err = assign_clat_prefix(data, override);
+			g_strfreev(override);
+		} else {
+			err = -EHOSTDOWN;
+		}
+	} else {
+		DBG("resolv of %s success, parse prefix", WKN_ADDRESS);
+		err = assign_clat_prefix(data, results);
+	}
+
+	switch (err) {
+	case 0:
+		DBG("new prefix %s/%u", data->clat_prefix,
+						data->clat_prefixlen);
+		break;
+	case -EALREADY:
+		/* No state change with same prefix */
+		DBG("no change in prefix");
+		return;
+	case -ERESTART:
+		DBG("prefix changed to %s/%u, do restart",
+						data->clat_prefix,
+						data->clat_prefixlen);
+		new_state = CLAT_STATE_RESTART;
+		break;
+	case -EHOSTDOWN:
+		DBG("failed to resolv %s, CLAT is not started", WKN_ADDRESS);
+		new_state = CLAT_STATE_FAILURE;
+		break;
+	default:
+		DBG("failed to assign prefix, error %d", err);
+		new_state = CLAT_STATE_FAILURE;
+		break;
+	}
+
+	if (data->state == CLAT_STATE_FAILURE) {
+		DBG("CLAT already in failure state, not transitioning state");
+		return;
+	}
+
+	/*
+	 * Do state transition only when doing initial query or when changing
+	 * state.
+	 */
+	if (data->state == CLAT_STATE_PREFIX_QUERY ||
+						data->state != new_state) {
+		DBG("State progress or state change");
+		data->state = new_state;
+
+		err = clat_run_task(data);
+		if (err && err != -EALREADY)
+			connman_error("failed to run CLAT, error %d", err);
+	}
+}
+
+static int clat_task_do_prefix_query(struct clat_data *data)
+{
+	DBG("");
+
+	/*
+	 * TODO handle this
+	 if (connman_inet_check_ipaddress(data->isp_64gateway) > 0) {
+		
+		return -EINVAL;
+	}*/
+
+	if (data->resolv_query_id > 0) {
+		DBG("previous query was running, abort it");
+		remove_resolv(data);
+	}
+
+	data->resolv = g_resolv_new(0);
+	if (!data->resolv) {
+		connman_error("CLAT cannot create resolv, stopping");
+		return -ENOMEM;
+	}
+
+	DBG("Trying to resolv %s gateway %s", WKN_ADDRESS, data->isp_64gateway);
+
+	g_resolv_set_address_family(data->resolv, AF_INET6);
+	data->resolv_query_id = g_resolv_lookup_hostname(data->resolv,
+					WKN_ADDRESS, prefix_query_cb, data);
+	if (data->resolv_query_id <= 0) {
+		DBG("failed to start hostname lookup for %s", WKN_ADDRESS);
+		return -ENOENT;
+	}
+
+	return 0;
+}
+
+static gboolean run_prefix_query(gpointer user_data)
+{
+	struct clat_data *data = user_data;
+
+	DBG("");
+
+	if (!data)
+		return G_SOURCE_REMOVE;
+
+	if (clat_task_do_prefix_query(data)) {
+		DBG("failed to run prefix query");
+		return G_SOURCE_REMOVE;
+	}
+
+	return G_SOURCE_CONTINUE;
+}
+
+static int clat_task_start_periodic_query(struct clat_data *data)
+{
+	DBG("");
+
+	if (data->prefix_query_id > 0) {
+		DBG("Already running");
+		return -EALREADY;
+	}
+
+	data->prefix_query_id = g_timeout_add(PREFIX_DAD_TIMEOUT,
+							run_prefix_query, data);
+	if (data->prefix_query_id <= 0) {
+		connman_error("CLAT failed to start periodic prefix query");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static void clat_task_stop_periodic_query(struct clat_data *data)
+{
+	DBG("");
+
+	if (data->prefix_query_id)
+		g_source_remove(data->prefix_query_id);
+
+	data->prefix_query_id = 0;
+
+	/* Cancel also ongoing resolv */
+	if (data->resolv_query_id)
+		remove_resolv(data);
+}
+
+static gboolean do_online_check(gpointer user_data)
+{
+	return G_SOURCE_REMOVE;
+}
+
+static int clat_task_start_online_check(struct clat_data *data)
+{
+	// TODO run this via wispr ?
+	do_online_check(data);
+	return 0;
+}
+
+static void clat_task_stop_online_check(struct clat_data *data)
+{
+	return;
+}
+
+
+static int derive_ipv6_address(struct clat_data *data, const char *ipv6_addr,
+						unsigned char ipv6_prefixlen)
+{
+	char** tokens;
+	char ipv6prefix[135] = { 0 };
+	int left;
+	int pos;
+	int i;
+
+	DBG("data %p IPv6 address %s/%u", data, ipv6_addr, ipv6_prefixlen);
+
+	if (!data || !ipv6_addr)
+		return -EINVAL;
+
+	tokens = g_strsplit(ipv6_addr, ":", 8);
+	if (!tokens) {
+		connman_error("CLAT failed to tokenize IPv6 address");
+		return -EINVAL;
+	}
+
+	left = 8 - (128 - (int)ipv6_prefixlen) / 16;
+	pos = 0;
+
+	for (i = 0; tokens[i] && i < left; i++) {
+		strncpy(&ipv6prefix[pos], tokens[i], 4);
+		pos += strlen(tokens[i]) + 1; // + ':'
+
+		if (i + 1 < left)
+			ipv6prefix[pos-1] = ':';
+	}
+
+	g_strfreev(tokens);
+
+	/*
+	 * TODO clat daemon made in perl does this a bit more intelligently,
+	 * https://github.com/toreanderson/clatd/blob/master/clatd#L442
+	 * 
+	 */
+	data->address = g_strconcat(ipv6prefix, "::", CLAT_SUFFIX, NULL);
+	data->addr_prefixlen = 128;
+
+	return 0;
+}
+
+static int clat_task_pre_configure(struct clat_data *data)
+{
+	struct connman_ipconfig *ipconfig;
+	struct connman_ipaddress *ipaddress;
+	const char *address;
+	unsigned char prefixlen;
+	int err;
+
+	DBG("");
+
+	ipconfig = connman_service_get_ipconfig(data->service, AF_INET6);
+	if (!ipconfig) {
+		DBG("No IPv6 ipconfig");
+		return -ENOENT;
+	}
+
+	ipaddress = connman_ipconfig_get_ipaddress(ipconfig);
+	if (!ipaddress) {
+		DBG("No IPv6 ipaddress in ipconfig %p", ipconfig);
+		return -ENOENT;
+	}
+
+	err = connman_ipaddress_get_ip(ipaddress, &address, &prefixlen);
+	if (err || !address) {
+		DBG("No IPv6 address set in ipaddress %p", ipaddress);
+		return -ENOENT;
+	}
+
+	DBG("IPv6 %s prefixlen %u", address, prefixlen);
+	data->ipv6address = g_strdup(address);
+	data->ipv6_prefixlen = prefixlen;
+
+	err = derive_ipv6_address(data, address, prefixlen);
+	if (err) {
+		connman_error("CLAT failed to derive IPv6 address from %s",
+						address);
+		return err;
+	}
+
+	DBG("Address IPv6 %s/%u -> CLAT address %s", data->ipv6address,
+					data->ipv6_prefixlen, data->address);
+
+	err = connman_nat6_prepare(ipconfig, TAYGA_CLAT_DEVICE, true);
+	if (err) {
+		connman_warn("CLAT failed to prepare nat and firewall %d", err);
+		return err;
+	}
+
+	clat_create_tayga_config(data);
+
+	if (create_task(data))
+		return -ENOMEM;
+
+	connman_task_add_argument(data->task, "--config", data->config_path);
+	connman_task_add_argument(data->task, "--mktun", NULL);
+
+	return 0;
+}
+
+/*
+5) set up routing and start TAYGA
+
+$ tayga --mktun
+$ ip link set dev clat up
+$ ip route add 2a00:e18:8000:6cd::c1a7 dev clat
+$ ip address add 192.0.0.4 dev clat
+$ ip -4 route add default dev clat
+$ tayga
+*/
+
+/* TODO add this to ipaddress.c as plugins/vpn.c uses this */
+static char *cidr_to_str(unsigned char cidr_netmask)
+{
+	struct in_addr netmask_in;
+	in_addr_t addr;
+	char netmask[INET_ADDRSTRLEN] = { 0 };
+	unsigned char prefix_len = 32;
+
+	if (cidr_netmask && cidr_netmask <= prefix_len)
+		prefix_len = cidr_netmask;
+
+	addr = 0xffffffff << (32 - prefix_len);
+	netmask_in.s_addr = htonl(addr);
+
+	if (!inet_ntop(AF_INET, &netmask_in, netmask, INET_ADDRSTRLEN)) {
+		connman_error("failed to convert CIDR %u", cidr_netmask);
+		return NULL;
+	}
+
+	DBG("CIDR %u to netmask %s", cidr_netmask, netmask);
+
+	return g_strdup(netmask);
+}
+
+static int clat_task_start_tayga(struct clat_data *data)
+{
+	struct connman_ipaddress *ipaddress;
+	char *netmask = NULL;
+	int err;
+	int index;
+	//$ ip link set dev clat up
+	// TODO wait for rtnl notify?
+	index = connman_inet_ifindex(TAYGA_CLAT_DEVICE);
+	if (index < 0) {
+		connman_warn("CLAT tayga not up yet?");
+		return -ENODEV;
+	}
+
+	DBG("");
+
+	err = connman_inet_ifup(index);
+	if (err && err != -EALREADY) {
+		connman_error("CLAT failed to bring interface %s up",
+							TAYGA_CLAT_DEVICE);
+		return err;
+	}
+
+	//$ ip route add 2a00:e18:8000:6cd::c1a7 dev clat
+	// TODO default route or...?
+	connman_inet_add_ipv6_network_route_with_metric(index, data->address,
+						NULL, data->addr_prefixlen,
+						CLAT_IPv6_METRIC);
+	//$ ip address add 192.0.0.2 dev clat
+	if (clat_settings.clat_device_use_netmask)
+		netmask = cidr_to_str(IPv4ADDR_NETMASK);
+
+	ipaddress = connman_ipaddress_alloc(AF_INET);
+	connman_ipaddress_set_ipv4(ipaddress, CLAT_IPv4ADDR, netmask, NULL);
+	connman_inet_set_address(index, ipaddress);
+
+	//$ ip -4 route add default dev clat
+	/* Set no address, all traffic should be forwarded to the device */
+	connman_inet_add_network_route_with_metric(index, CLAT_INADDR_ANY,
+							CLAT_INADDR_ANY,
+							CLAT_INADDR_ANY,
+							CLAT_IPv4_METRIC);
+	connman_ipaddress_free(ipaddress);
+	g_free(netmask);
+
+	if (create_task(data))
+		return -ENOMEM;
+
+	connman_task_add_argument(data->task, "--config", data->config_path);
+	connman_task_add_argument(data->task, "--nodetach", NULL);
+	connman_task_add_argument(data->task, "-d", NULL);
+
+	return 0;
+}
+
+void clat_dad_cb(struct nd_neighbor_advert *reply, unsigned int length,
+					struct in6_addr *addr,
+					void *user_data)
+{
+	char ipv6_addr[INET6_ADDRSTRLEN];
+
+	// This reply can be ignored
+	DBG("got reply %p length %u", reply, length);
+
+	if (addr && inet_ntop(AF_INET6, addr, ipv6_addr, INET6_ADDRSTRLEN))
+		DBG("IPv6 address %s", ipv6_addr);
+
+	return;
+}
+
+static gboolean clat_task_run_dad(gpointer user_data)
+{
+	struct clat_data *data = user_data;
+	unsigned char addr[sizeof(struct in6_addr)];
+	int err = 0;
+
+	DBG("");
+
+	if (inet_pton(AF_INET6, data->address, addr) != 1) {
+		connman_error("failed to pton address %s", data->address);
+		return G_SOURCE_REMOVE;
+	}
+
+	err = connman_inet_ipv6_do_dad(data->ifindex, 100,
+						(struct in6_addr *)addr,
+						clat_dad_cb, data);
+	if (err) {
+		connman_error("CLAT failed to send dad: %d", err);
+		return G_SOURCE_REMOVE;
+	}
+
+	return G_SOURCE_CONTINUE;
+}
+
+static int clat_task_start_dad(struct clat_data *data)
+{
+	DBG("");
+
+	if (!clat_settings.dad_enabled) {
+		DBG("DAD disabled by config");
+		return 0;
+	}
+
+	data->dad_id = g_timeout_add(DAD_TIMEOUT, clat_task_run_dad, data);
+
+	if (data->dad_id <= 0) {
+		connman_error("CLAT failed to start DAD timeout");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int clat_task_stop_dad(struct clat_data *data)
+{
+	DBG("");
+
+	if (data->dad_id)
+		g_source_remove(data->dad_id);
+
+	data->dad_id = 0;
+
+	return 0;
+}
+
+static int clat_task_post_configure(struct clat_data *data)
+{
+	struct connman_ipconfig *ipconfig;
+	struct connman_ipaddress *ipaddress;
+	char *netmask = NULL;
+	int index;
+
+	//$ ip link set dev clat up
+	// TODO wait for rtnl notify?
+
+	ipconfig = connman_service_get_ipconfig(data->service, AF_INET6);
+	if (ipconfig)
+		connman_nat6_restore(ipconfig);
+
+	DBG("ipconfig %p", ipconfig);
+
+	index = connman_inet_ifindex(TAYGA_CLAT_DEVICE);
+	if (index >= 0) {
+		ipaddress = connman_ipaddress_alloc(AF_INET);
+		connman_inet_del_network_route_with_metric(index, CLAT_IPv4ADDR,
+							CLAT_IPv4_METRIC);
+
+		if (clat_settings.clat_device_use_netmask)
+			netmask = cidr_to_str(IPv4ADDR_NETMASK);
+
+		connman_ipaddress_set_ipv4(ipaddress, CLAT_IPv4ADDR, netmask,
+							NULL);
+		g_free(netmask);
+
+		connman_inet_clear_address(index, ipaddress);
+		connman_inet_del_ipv6_network_route_with_metric(index,
+							data->address,
+							data->addr_prefixlen,
+							CLAT_IPv6_METRIC);
+		connman_inet_ifdown(index);
+		connman_ipaddress_free(ipaddress);
+	} else {
+		DBG("CLAT tayga interface not up, nothing to do");
+	}
+
+	if (create_task(data))
+		return -ENOMEM;
+
+	connman_task_add_argument(data->task, "--config", data->config_path);
+	connman_task_add_argument(data->task, "--rmtun", NULL);
+
+	return 0;
+}
+
+static void clat_task_exit(struct connman_task *task, int exit_code,
+								void *user_data)
+{
+	struct clat_data *data = user_data;
+	int err;
+
+	DBG("state %d/%s", data->state, state2string(data->state));
+
+	if (exit_code)
+		connman_warn("CLAT task failed with code %d", exit_code);
+
+	if (task != data->task) {
+		connman_warn("CLAT task differs, nothing done");
+		return;
+	}
+
+	destroy_task(data);
+
+	switch (data->state) {
+	case CLAT_STATE_IDLE:
+	case CLAT_STATE_STOPPED:
+	case CLAT_STATE_FAILURE:
+		DBG("CLAT task exited in state %d/%s", data->state,
+						state2string(data->state));
+		break;
+	case CLAT_STATE_PREFIX_QUERY:
+	case CLAT_STATE_PRE_CONFIGURE:
+	case CLAT_STATE_RUNNING:
+		if (exit_code)
+			data->state = CLAT_STATE_FAILURE;
+		else
+			DBG("run next state %d/%s", data->state + 1,
+						state2string(data->state + 1));
+
+		err = clat_run_task(data);
+		if (err && err != -EALREADY)
+			connman_error("failed to run CLAT, error %d", err);
+		return;
+	case CLAT_STATE_POST_CONFIGURE:
+		DBG("CLAT process ended");
+		data->state = CLAT_STATE_STOPPED;
+		break;
+	case CLAT_STATE_RESTART:
+		DBG("CLAT task return when restarting");
+		return;
+	}
+
+	/*
+	 * Not continuing with running task or handling restart, clear all data
+	 * in case of terminating failure or when stopping clat.
+	 */
+	clat_data_clear(data);
+}
+
+static int clat_run_task(struct clat_data *data)
+{
+	int fd_out;
+	int fd_err;
+	int err = 0;
+
+	DBG("state %d/%s", data->state, state2string(data->state));
+
+	switch (data->state) {
+	case CLAT_STATE_IDLE:
+		data->state = CLAT_STATE_PREFIX_QUERY;
+		/* Get the prefix from the ISP NAT service */
+		err = clat_task_do_prefix_query(data);
+		if (err && err != -EALREADY) {
+			connman_error("CLAT failed to start prefix query");
+			break;
+		}
+
+		return 0;
+
+	case CLAT_STATE_PREFIX_QUERY:
+		err = clat_task_pre_configure(data);
+		if (err) {
+			connman_error("CLAT failed to create pre-configure "
+								"task");
+			break;
+		}
+
+		data->state = CLAT_STATE_PRE_CONFIGURE;
+		break;
+	case CLAT_STATE_PRE_CONFIGURE:
+		err = clat_task_start_tayga(data);
+		if (err) {
+			connman_error("CLAT failed to create run task");
+			break;
+		}
+
+		data->state = CLAT_STATE_RUNNING;
+
+		err = clat_task_start_periodic_query(data);
+		if (err && err != -EALREADY)
+			connman_warn("CLAT failed to start periodic prefix "
+								"query");
+
+		err = clat_task_start_dad(data);
+		if (err && err != -EALREADY)
+			connman_warn("CLAT failed to start periodic DAD");
+
+		break;
+	/* If either running or stopped state and run is called do cleanup */
+	case CLAT_STATE_RUNNING:
+	case CLAT_STATE_STOPPED:
+		clat_task_stop_periodic_query(data);
+		clat_task_stop_dad(data);
+		clat_task_stop_online_check(data);
+
+		err = clat_task_post_configure(data);
+		if (err) {
+			connman_error("CLAT failed to create post-configure "
+								"task");
+			break;
+		}
+		data->state = CLAT_STATE_POST_CONFIGURE;
+
+		break;
+	case CLAT_STATE_POST_CONFIGURE:
+		connman_warn("CLAT run task called in post-configure state");
+		data->state = CLAT_STATE_STOPPED;
+		return 0;
+	case CLAT_STATE_FAILURE:
+		DBG("CLAT entered failure state, stop all that is running");
+
+		destroy_task(data);
+
+		/* Do post configure if the interface is up */
+		err = clat_task_post_configure(data);
+		if (err && err != -ENODEV)
+			connman_error("CLAT failed to create post-configure "
+						"task in failure state");
+
+		clat_task_stop_periodic_query(data);
+		clat_task_stop_dad(data);
+		clat_task_stop_online_check(data);
+
+		/* Remain in failure state, can be started via clat_start(). */
+		data->state = CLAT_STATE_FAILURE;
+
+		if (err)
+			return err;
+
+		break;
+	case CLAT_STATE_RESTART:
+		destroy_task(data);
+
+		/* Run as stopped -> does cleanup */
+		data->state = CLAT_STATE_STOPPED;
+		err = clat_run_task(data);
+		if (err && err != -EALREADY) {
+			connman_error("CLAT failed to start cleanup task");
+			data->state = CLAT_STATE_FAILURE;
+		}
+
+		data->state = CLAT_STATE_IDLE;
+		break;
+	}
+
+	if (!err) {
+		DBG("CLAT run task %p", data->task);
+		err = connman_task_run(data->task, clat_task_exit, data, NULL,
+							&fd_out, &fd_err);
+	}
+
+	if (err) {
+		connman_error("CLAT task failed to run, error %d/%s",
+							err, strerror(-err));
+		data->state = CLAT_STATE_FAILURE;
+		destroy_task(data);
+	} else {
+		if (data->out_ch)
+			close_io_channel(data, data->out_ch);
+
+		data->out_ch = g_io_channel_unix_new(fd_out);
+		data->out_ch_id = g_io_add_watch(data->out_ch,
+						G_IO_IN | G_IO_ERR | G_IO_HUP,
+						(GIOFunc)io_channel_cb, data);
+		if (data->err_ch)
+			close_io_channel(data, data->err_ch);
+
+		data->err_ch = g_io_channel_unix_new(fd_err);
+		data->err_ch_id = g_io_add_watch(data->err_ch,
+						G_IO_IN | G_IO_ERR | G_IO_HUP,
+						(GIOFunc)io_channel_cb, data);
+	}
+
+	DBG("in state %d/%s", data->state, state2string(data->state));
+
+	return err;
+}
+
+static int clat_start(struct clat_data *data)
+{
+	DBG("state %d/%s", data->state, state2string(data->state));
+
+	if (!data)
+		return -EINVAL;
+
+	if (is_running(data->state))
+		return -EALREADY;
+
+	data->state = CLAT_STATE_IDLE;
+	clat_run_task(data);
+
+	return 0;
+}
+
+static int clat_stop(struct clat_data *data)
+{
+	int err;
+
+	if (!data)
+		return -EINVAL;
+
+	DBG("state %d/%s", data->state, state2string(data->state));
+
+	destroy_task(data);
+
+	/* Run as stopped -> does cleanup */
+	data->state = CLAT_STATE_STOPPED;
+	err = clat_run_task(data);
+	if (err && err != -EALREADY) {
+		connman_error("CLAT failed to start cleanup task");
+		data->state = CLAT_STATE_FAILURE;
+	}
+
+	/* Sets as idle */
+	clat_data_clear(data);
+
+	return err;
+}
+
+static int clat_failure(struct clat_data *data)
+{
+	return 0;
+}
+
+static void clat_new_rtnl_gateway(int index, const char *dst,
+						const char *gateway, int metric,
+						unsigned char rtm_protocol)
+{
+	struct clat_data *data = get_data();
+
+	DBG("%d dst %s gateway %s metric %d", index, dst, gateway, metric);
+
+	/* Not the cellular device we are monitoring. */
+	if (index != data->ifindex)
+		return;
+
+	if (rtm_protocol != RTPROT_RA && rtm_protocol != RTPROT_DHCP) {
+		DBG("rtm_protocol not RA|DHCP");
+		return;
+	}
+
+	/*if (!connman_inet_is_any_addr(dst, AF_INET6)) {
+		DBG("dst %s != IPv6 ANY: %s", dst, IPV6_ANY);
+		return;
+	}*/
+
+	g_free(data->isp_64gateway);
+	data->isp_64gateway = g_strdup(gateway);
+
+	// TODO: perhaps store also dst and metric?
+}
+
+static void clat_del_rtnl_gateway(int index, const char *dst,
+						const char *gateway, int metric,
+						unsigned char rtm_protocol)
+{
+	struct clat_data *data = get_data();
+	
+	DBG("%d dst %s gateway %s metric %d", index, dst, gateway, metric);
+
+	if (index != data->ifindex)
+		return;
+
+	if (rtm_protocol != RTPROT_RA && rtm_protocol != RTPROT_DHCP) {
+		DBG("rtm_protocol not RA|DHCP");
+		return;
+	}
+
+	/* We lost our gateway, shut down clat */
+	if (!g_strcmp0(data->isp_64gateway, gateway)) {
+		DBG("CLAT gateway %s gone", data->isp_64gateway);
+		clat_stop(data);
+	}
+}
+
+static struct connman_rtnl clat_rtnl = {
+	.name			= "clat",
+	.newgateway6		= clat_new_rtnl_gateway,
+	.delgateway6		= clat_del_rtnl_gateway,
+};
+
+static void clat_ipconfig_changed(struct connman_service *service,
+					struct connman_ipconfig *ipconfig)
+{
+	struct connman_network *network;
+	struct clat_data *data = get_data();
+	enum connman_service_state state;
+	int err;
+
+	if (service || !data->service)
+		return;
+
+	DBG("service %p ipconfig %p", service, ipconfig);
+
+	if (service != data->service || connman_service_get_type(service) !=
+						CONNMAN_SERVICE_TYPE_CELLULAR) {
+		DBG("Not tracking service %p/%s or not cellular", service,
+				connman_service_get_identifier(service));
+		return;
+	}
+
+	if (connman_ipconfig_get_config_type(ipconfig) ==
+						CONNMAN_IPCONFIG_TYPE_IPV4) {
+		DBG("cellular %p has IPv4 config, stop CLAT", service);
+		clat_stop(data);
+		return;
+	}
+
+	if (service != connman_service_get_default()) {
+		DBG("cellular service %p is not default, stop CLAT", service);
+		clat_stop(data);
+		return;
+	}
+
+	network = connman_service_get_network(service);
+	if (!network || !connman_network_get_connected(network)) {
+		DBG("network %p not connected, stop CLAT", network);
+		clat_stop(data);
+		return;
+	}
+
+	state = connman_service_get_state(service);
+
+	if (state == CONNMAN_SERVICE_STATE_READY ||
+				state == CONNMAN_SERVICE_STATE_ONLINE) {
+		DBG("service %p ready|online, start CLAT", service);
+		err = clat_start(data);
+		if (err && err != -EALREADY)
+			connman_error("CLAT failed to start, error %d", err);
+	}
+}
+
+static bool has_ipv4_address(struct connman_service *service)
+{
+	struct connman_ipconfig *ipconfig;
+	struct connman_ipaddress *ipaddress;
+	enum connman_ipconfig_method method;
+	const char *address;
+	unsigned char prefixlen;
+	int err;
+
+	ipconfig = connman_service_get_ipconfig(service, AF_INET);
+	DBG("IPv4 ipconfig %p", ipconfig);
+
+	ipaddress = connman_ipconfig_get_ipaddress(ipconfig);
+	DBG("IPv4 ipaddress %p", ipaddress);
+
+	err = connman_ipaddress_get_ip(ipaddress, &address, &prefixlen);
+	if (err) {
+		DBG("IPv4 is not configured on cellular service %p", service);
+		return false;
+	}
+
+	if (!address) {
+		DBG("no IPv4 address on cellular service %p", service);
+		return false;
+	}
+
+	method = connman_service_get_ipconfig_method(service,
+						CONNMAN_IPCONFIG_TYPE_IPV4);
+	switch (method) {
+	case CONNMAN_IPCONFIG_METHOD_UNKNOWN:
+	case CONNMAN_IPCONFIG_METHOD_OFF:
+		DBG("IPv4 method unknown/off, address is old");
+		return false;
+	case CONNMAN_IPCONFIG_METHOD_FIXED:
+	case CONNMAN_IPCONFIG_METHOD_MANUAL:
+	case CONNMAN_IPCONFIG_METHOD_DHCP:
+	case CONNMAN_IPCONFIG_METHOD_AUTO:
+		break;
+	}
+
+	DBG("IPv4 address %s set for service %p", address, service);
+	return true;
+}
+
+static void clat_default_changed(struct connman_service *service)
+{
+	struct connman_network *network;
+	struct clat_data *data = get_data();
+
+	if (!service || !data->service)
+		return;
+
+	DBG("service %p", service);
+
+	if (!is_running(data->state)) {
+		DBG("CLAT not running, default change not affected");
+		return;
+	}
+
+	if (data->service && data->service != service) {
+		DBG("Tracked cellular service %p is not default, stop CLAT",
+							data->service);
+		clat_stop(data);
+		return;
+	}
+
+	network = connman_service_get_network(service);
+	if (!network || !connman_network_get_connected(network)) {
+		DBG("network %p not connected, stop CLAT", network);
+		clat_stop(data);
+		return;
+	}
+
+	if (connman_network_is_configured(network,
+					CONNMAN_IPCONFIG_TYPE_IPV4) &&
+					has_ipv4_address(data->service)) {
+		DBG("IPv4 is configured on cellular network %p, stop CLAT",
+							network);
+		clat_stop(data);
+		return;
+	}
+}
+
+static void clat_service_state_changed(struct connman_service *service,
+					enum connman_service_state state)
+{
+	struct connman_network *network;
+	struct clat_data *data = get_data();
+	char *ifname;
+	int err;
+
+	if (!service || connman_service_get_type(service) !=
+						CONNMAN_SERVICE_TYPE_CELLULAR)
+		return;
+
+	DBG("cellular service %p", service);
+
+	switch (state) {
+	/* Not connected */
+	case CONNMAN_SERVICE_STATE_UNKNOWN:
+	case CONNMAN_SERVICE_STATE_IDLE:
+	case CONNMAN_SERVICE_STATE_DISCONNECT:
+	case CONNMAN_SERVICE_STATE_FAILURE:
+		/* Stop clat if the service goes offline */
+		if (service == data->service) {
+			DBG("offline state, stop CLAT");
+			clat_stop(data);
+			data->service = NULL;
+		}
+		return;
+	/* Connecting does not need yet clat as there is no network.*/
+	case CONNMAN_SERVICE_STATE_ASSOCIATION:
+	case CONNMAN_SERVICE_STATE_CONFIGURATION:
+		DBG("association|configuration, assign service %p", service);
+		data->service = service;
+		return;
+	/* Connected, start clat. */
+	case CONNMAN_SERVICE_STATE_READY:
+		if (service != data->service)
+			return;
+
+		if (connman_service_get_default() != data->service) {
+			DBG("CLAT service is not default service");
+			return;
+		}
+
+		if (is_running(data->state)) {
+			DBG("CLAT is already running in state %d/%s",
+						data->state,
+						state2string(data->state));
+			return;
+		}
+
+		DBG("ready, initialize CLAT");
+		break;
+	case CONNMAN_SERVICE_STATE_ONLINE:
+		if (service != data->service)
+			return;
+
+		if (connman_service_get_default() != data->service) {
+			DBG("CLAT service is not default service");
+			return;
+		}
+
+		if (!is_running(data->state)) {
+			DBG("online, CLAT is not running yet, start it first");
+			break;
+		}
+
+		goto onlinecheck;
+	}
+
+	network = connman_service_get_network(service);
+	if (!network) {
+		DBG("No network yet, not starting clat");
+		return;
+	}
+
+	if (data->ifindex < 0) {
+		DBG("ifindex not set, get it from network");
+		data->ifindex = connman_network_get_index(network);
+	}
+
+	if (data->ifindex < 0) {
+		DBG("Interface not up, not starting clat");
+		return;
+	}
+
+	ifname = connman_inet_ifname(data->ifindex);
+	if (!ifname) {
+		DBG("Interface %d not up, not starting clat", data->ifindex);
+		return;
+	}
+
+	g_free(ifname);
+
+	/* Network may have DHCP/AUTO set without address */
+	if (connman_network_is_configured(network,
+					CONNMAN_IPCONFIG_TYPE_IPV4) &&
+					has_ipv4_address(data->service)) {
+		DBG("Service %p has IPv4 address on interface %d, not "
+						"starting CLAT", data->service,
+						data->ifindex);
+		return;
+	}
+
+	err = clat_start(data);
+	if (err && err != -EALREADY)
+		connman_error("failed to start CLAT, error %d", err);
+
+onlinecheck:
+	if (state == CONNMAN_SERVICE_STATE_ONLINE &&
+					data->state == CLAT_STATE_RUNNING) {
+		DBG("online, CLAT is running, do online check");
+
+		err = clat_task_start_online_check(data);
+		if (err && err != -EALREADY)
+			connman_error("CLAT failed to do online check");
+	}
+}
+
+static struct connman_notifier clat_notifier = {
+	.name			= "clat",
+	.ipconfig_changed	= clat_ipconfig_changed,
+	.default_changed	= clat_default_changed,
+	.service_state_changed	= clat_service_state_changed,
+};
+
+static int clat_init(void)
+{
+	GKeyFile *config;
+	int err;
+
+	DBG("");
+
+	config = load_clat_config(CLATCONFIGFILE);
+	if (config) {
+		parse_clat_config(config);
+		g_key_file_free(config);
+	}
+
+	__data = clat_data_init();
+	if (!__data) {
+		connman_error("CLAT: cannot initialize data");
+		return -ENOMEM;
+	}
+
+	err = connman_notifier_register(&clat_notifier);
+	if (err) {
+		connman_error("CLAT: notifier register failed");
+		return err;
+	}
+
+	err = connman_rtnl_register(&clat_rtnl);
+	if (err) {
+		connman_error("CLAT: rtnl notifier register failed");
+		return err;
+	}
+
+	connman_rtnl_handle_rtprot_ra(true);
+
+	return 0;
+}
+
+static void clat_exit(void)
+{
+	DBG("");
+
+	if (is_running(__data->state))
+		clat_stop(__data);
+
+	connman_notifier_unregister(&clat_notifier);
+	connman_rtnl_handle_rtprot_ra(false);
+	connman_rtnl_unregister(&clat_rtnl);
+
+	clat_data_free(__data);
+	clear_clat_config();
+}
+
+CONNMAN_PLUGIN_DEFINE(clat, "CLAT plugin", VERSION,
+			CONNMAN_PLUGIN_PRIORITY_DEFAULT, clat_init, clat_exit)
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * End:
+ */

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -31,6 +31,7 @@
 #include "../include/nat.h"
 #include <connman/notifier.h>
 #include <connman/rtnl.h>
+#include <connman/setting.h>
 
 #include <gweb/gresolv.h>
 
@@ -77,6 +78,8 @@ struct clat_data {
 	int err_ch_id;
 	GIOChannel *out_ch;
 	GIOChannel *err_ch;
+
+	bool tethering_on;
 };
 
 #define DEFAULT_TAYGA_BIN		"/usr/local/bin/tayga"
@@ -91,7 +94,7 @@ struct clat_data {
 #define CLAT_IPv6_METRIC		1024
 #define CLAT_SUFFIX			"c1a7"
 
-#define PREFIX_QUERY_TIMEOUT		10000		/* 10 seconds */
+#define PREFIX_QUERY_TIMEOUT		600000		/* 10 seconds */
 #define DAD_TIMEOUT			600000		/* 10 minutes */
 
 static const char GLOBAL_PREFIX[] = "64:ff9b::";
@@ -103,6 +106,7 @@ static struct {
 	bool resolv_always_succeeds;
 	bool clat_device_use_netmask;
 	bool tayga_use_ipv6_conf;
+	bool tayga_use_strict_frag_hdr;
 } clat_settings = {
 	.tayga_bin = NULL,
 
@@ -117,6 +121,9 @@ static struct {
 
 	/* Write IPv6 address of the interface used to the tayga config */
 	.tayga_use_ipv6_conf = false,
+
+	/* Value for strict-frag-hdr, defaults on */
+	.tayga_use_strict_frag_hdr = true,
 };
 
 #define CLATCONFIGFILE			CONFIGDIR "/clat.conf"
@@ -125,6 +132,7 @@ static struct {
 #define CONF_RESOLV_ALWAYS_SUCCEEDS	"ResolvAlwaysSucceeds"
 #define CONF_CLAT_USE_NETMASK		"ClatDeviceUseNetmask"
 #define CONF_TAYGA_USE_IPV6_CONF	"TaygaRequiresIPv6Address"
+#define CONF_TAYGA_USE_STRICT_FRAG_HDR	"TaygaStrictFragHdr"
 
 struct clat_data *__data = NULL;
 
@@ -201,6 +209,14 @@ static void parse_clat_config(GKeyFile *config)
 						&error);
 	if (!error)
 		clat_settings.tayga_use_ipv6_conf = boolean;
+
+	g_clear_error(&error);
+
+	boolean = g_key_file_get_boolean(config, group,
+						CONF_TAYGA_USE_STRICT_FRAG_HDR,
+						&error);
+	if (!error)
+		clat_settings.tayga_use_strict_frag_hdr = boolean;
 
 	g_clear_error(&error);
 }
@@ -446,6 +462,16 @@ static int clat_create_tayga_config(struct clat_data *data)
 	 */
 	g_string_append_printf(str, "map %s %s\n", CLAT_IPv4ADDR,
 						data->address);
+
+	/* ippool.c apparently defaults to 24 subnet */
+	g_string_append_printf(str, "dynamic-pool %s/%u\n",
+				connman_setting_get_string(
+					"TetheringSubnetBlock"),
+				24);
+
+	g_string_append_printf(str, "strict-frag-hdr %s\n",
+				clat_settings.tayga_use_strict_frag_hdr ?
+					"on" : "off");
 
 	buf = g_string_free(str, FALSE);
 
@@ -1216,6 +1242,39 @@ static void clat_task_exit(struct connman_task *task, int exit_code,
 	clat_data_clear(data);
 }
 
+static void setup_double_nat(struct clat_data *data)
+{
+	int err;
+
+	if (!data)
+		return;
+
+	if (data->tethering_on && data->state == CLAT_STATE_RUNNING) {
+		DBG("tethering enabled when CLAT is running, override nat");
+
+		err = connman_nat_enable_double_nat_override(TAYGA_CLAT_DEVICE,
+						"192.0.0.0", IPv4ADDR_NETMASK);
+		if (err && err != -EINPROGRESS)
+			connman_error("Failed to setup double nat for tether");
+	} else {
+		DBG("Remove nat override");
+		connman_nat_disable_double_nat_override(TAYGA_CLAT_DEVICE);
+	}
+}
+
+static void stop_running(struct clat_data *data)
+{
+	if (!data)
+		return;
+
+	clat_task_stop_periodic_query(data);
+	clat_task_stop_dad(data);
+	clat_task_stop_online_check(data);
+
+	data->tethering_on = false;
+	setup_double_nat(data);
+}
+
 static int clat_run_task(struct clat_data *data)
 {
 	int fd_out;
@@ -1268,9 +1327,7 @@ static int clat_run_task(struct clat_data *data)
 	/* If either running or stopped state and run is called do cleanup */
 	case CLAT_STATE_RUNNING:
 	case CLAT_STATE_STOPPED:
-		clat_task_stop_periodic_query(data);
-		clat_task_stop_dad(data);
-		clat_task_stop_online_check(data);
+		stop_running(data);
 
 		err = clat_task_post_configure(data);
 		if (err) {
@@ -1296,9 +1353,7 @@ static int clat_run_task(struct clat_data *data)
 			connman_error("CLAT failed to create post-configure "
 						"task in failure state");
 
-		clat_task_stop_periodic_query(data);
-		clat_task_stop_dad(data);
-		clat_task_stop_online_check(data);
+		stop_running(data);
 
 		/* Remain in failure state, can be started via clat_start(). */
 		data->state = CLAT_STATE_FAILURE;
@@ -1352,6 +1407,8 @@ static int clat_run_task(struct clat_data *data)
 		data->err_ch_id = g_io_add_watch(data->err_ch,
 						G_IO_IN | G_IO_ERR | G_IO_HUP,
 						(GIOFunc)io_channel_cb, data);
+
+		setup_double_nat(data);
 	}
 
 	DBG("in state %d/%s", data->state, state2string(data->state));
@@ -1714,11 +1771,22 @@ onlinecheck:
 	}
 }
 
+static void clat_tethering_changed(struct connman_technology *tech, bool on)
+{
+	struct clat_data *data = get_data();
+
+	/* We just need to know if tethering is enabled or not */
+	data->tethering_on = on;
+
+	setup_double_nat(data);
+}
+
 static struct connman_notifier clat_notifier = {
 	.name			= "clat",
 	.ipconfig_changed	= clat_ipconfig_changed,
 	.default_changed	= clat_default_changed,
 	.service_state_changed	= clat_service_state_changed,
+	.tethering_changed	= clat_tethering_changed,
 };
 
 static int clat_init(void)

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -243,7 +243,7 @@ static void clear_clat_config(void)
 	g_free(clat_settings.tayga_bin);
 }
 
-static bool is_running(enum clat_state state)
+static bool is_running_state(enum clat_state state)
 {
 	switch (state) {
 	case CLAT_STATE_IDLE:
@@ -821,6 +821,14 @@ static int assign_clat_prefix(struct clat_data *data, char **results)
 static int clat_task_start_periodic_query(struct clat_data *data);
 static int clat_task_restart_periodic_query(struct clat_data *data);
 
+static bool clat_is_running(struct clat_data *data)
+{
+	if (!data)
+		return false;
+
+	return is_running_state(data->state);
+}
+
 static void prefix_query_cb(GResolvResultStatus status,
 					char **results, gpointer user_data)
 {
@@ -834,7 +842,7 @@ static void prefix_query_cb(GResolvResultStatus status,
 
 	if (!data->resolv && !data->resolv_query_id) {
 		DBG("resolv was already cleared, running state: %s",
-					is_running(data->state) ? "yes" : "no");
+					clat_is_running(data) ? "yes" : "no");
 		return;
 	}
 
@@ -903,7 +911,7 @@ static void prefix_query_cb(GResolvResultStatus status,
 		new_state = CLAT_STATE_RESTART;
 		break;
 	case -EHOSTDOWN:
-		if (is_running(data->state)) {
+		if (clat_is_running(data)) {
 			DBG("failed to resolv %s, CLAT is stopped",
 								WKN_ADDRESS);
 			new_state = CLAT_STATE_STOPPED;
@@ -928,7 +936,7 @@ static void prefix_query_cb(GResolvResultStatus status,
 			return;
 		}
 
-		if (is_running(data->state)) {
+		if (clat_is_running(data)) {
 			DBG("query timeouted, retry after %d seconds",
 						PREFIX_QUERY_RETRY_TIMEOUT);
 			clat_task_restart_periodic_query(data);
@@ -1729,7 +1737,7 @@ static int clat_start(struct clat_data *data)
 	if (!data)
 		return -EINVAL;
 
-	if (is_running(data->state))
+	if (clat_is_running(data))
 		return -EALREADY;
 
 	data->state = CLAT_STATE_IDLE;
@@ -1745,7 +1753,7 @@ static int clat_stop(struct clat_data *data)
 
 	DBG("state %d/%s", data->state, state2string(data->state));
 
-	if (!is_running(data->state)) {
+	if (!clat_is_running(data)) {
 		DBG("already stopping/stopped");
 		return -EALREADY;
 	}
@@ -2036,12 +2044,18 @@ static void clat_default_changed(struct connman_service *service)
 	enum connman_ipconfig_type type = CONNMAN_IPCONFIG_TYPE_IPV4;
 	int err;
 
-	if (!service)
-		return;
-
 	DBG("service %p", service);
 
 	data = get_data();
+
+	if (!service) {
+		if (clat_is_running(data)) {
+			DBG("CLAT stop with NULL default service");
+			clat_stop(data);
+		}
+
+		return;
+	}
 
 	if (data->service != service) {
 		if (!is_supported_service_type(service)) {
@@ -2060,7 +2074,7 @@ static void clat_default_changed(struct connman_service *service)
 	state = connman_service_get_state(data->service);
 
 	/* Tracked service is the default service but is not running -> start */
-	if (!is_running(data->state) &&	is_valid_start_state(state)) {
+	if (!clat_is_running(data) && is_valid_start_state(state)) {
 		DBG("Tracked service is default, start CLAT");
 
 		err = try_clat_start(data);
@@ -2129,7 +2143,7 @@ static void clat_service_state_changed(struct connman_service *service,
 			return;
 		}
 
-		if (is_running(data->state)) {
+		if (clat_is_running(data)) {
 			DBG("CLAT is already running in state %d/%s",
 						data->state,
 						state2string(data->state));
@@ -2147,7 +2161,7 @@ static void clat_service_state_changed(struct connman_service *service,
 			return;
 		}
 
-		if (!is_running(data->state)) {
+		if (!clat_is_running(data)) {
 			DBG("online, CLAT is not running yet, start it first");
 			break;
 		}

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -548,12 +548,13 @@ static struct prefix_entry *new_prefix_entry(const char *address)
 	if (!address)
 		return NULL;
 
-	tokens = g_strsplit(address, "/", 2);
 	entry = g_new0(struct prefix_entry, 1);
 	if (!entry)
 		return NULL;
 
 	DBG("entry %p", entry);
+
+	tokens = g_strsplit(address, "/", 2);
 
 	/* Result has a global prefix */
 	if (g_str_has_prefix(address, GLOBAL_PREFIX)) {
@@ -568,7 +569,7 @@ static struct prefix_entry *new_prefix_entry(const char *address)
 	} else {
 		DBG("address does not contain a valid prefix");
 		free_prefix_entry(entry);
-		return NULL;
+		entry = NULL;
 	}
 	/*
 	 * TODO: Check the prefixlenght from other than ones with GLOBAL_PREFIX
@@ -579,13 +580,16 @@ static struct prefix_entry *new_prefix_entry(const char *address)
 	if (tokens)
 		g_strfreev(tokens);
 
+	if (!entry)
+		return NULL;
+
 	/*
 	 * Addresses with < 16 prefixlen should not be possible, also ignore
 	 * single address prefixes as there is no room for additional address.
 	 */
 	if (entry->prefixlen > 120 || entry->prefixlen < 16) {
 		DBG("Invalid prefixlen %u", entry->prefixlen);
-		g_free(entry);
+		free_prefix_entry(entry);
 		return NULL;
 	}
 
@@ -739,11 +743,12 @@ static void prefix_query_cb(GResolvResultStatus status,
 
 	if (status != G_RESOLV_RESULT_STATUS_SUCCESS &&
 					clat_settings.resolv_always_succeeds) {
-		gchar **override = g_new0(char*, 1);
+		gchar **override = g_new0(char*, 2);
 
 		DBG("ignore resolv result %d", status);
 
 		override[0] = g_strdup("64:ff9b::/96");
+		override[1] = NULL;
 		err = assign_clat_prefix(data, override);
 		g_strfreev(override);
 	}
@@ -999,6 +1004,7 @@ static int derive_ipv6_address(struct clat_data *data, const char *ipv6_addr,
 	 * https://github.com/toreanderson/clatd/blob/master/clatd#L442
 	 * 
 	 */
+	g_free(data->address);
 	data->address = g_strconcat(ipv6prefix, "::", CLAT_IPv6_SUFFIX, NULL);
 	data->addr_prefixlen = 128;
 
@@ -1034,6 +1040,8 @@ static int clat_task_pre_configure(struct clat_data *data)
 	}
 
 	DBG("IPv6 %s prefixlen %u", address, prefixlen);
+
+	g_free(data->ipv6address);
 	data->ipv6address = g_strdup(address);
 	data->ipv6_prefixlen = prefixlen;
 

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -50,6 +50,12 @@ enum clat_state {
 	CLAT_STATE_RESTART,
 };
 
+enum tethering_state {
+	TETHERING_UNSET = 0,
+	TETHERING_ON,
+	TETHERING_OFF,
+};
+
 struct clat_data {
 	struct connman_service *service;
 	struct connman_task *task;
@@ -78,7 +84,7 @@ struct clat_data {
 	GIOChannel *out_ch;
 	GIOChannel *err_ch;
 
-	bool tethering_on;
+	enum tethering_state tethering;
 	bool do_restart;
 };
 
@@ -320,12 +326,18 @@ static gboolean io_channel_cb(GIOChannel *source, GIOCondition condition,
 	const char *type = (source == data->out_ch ? "STDOUT" :
 				(source == data->err_ch ? "STDERR" : "NaN"));
 
-	if ((condition & G_IO_IN) &&
-		g_io_channel_read_line(source, &str, NULL, NULL, NULL) ==
-							G_IO_STATUS_NORMAL) {
+	if (condition & (G_IO_IN | G_IO_PRI)) {
+		GIOStatus status;
+
+		status = g_io_channel_read_line(source, &str, NULL, NULL, NULL);
+		if (status != G_IO_STATUS_NORMAL && status != G_IO_STATUS_EOF) {
+			DBG("cannot read line, status %d", status);
+			return G_SOURCE_CONTINUE;
+		}
+
 		str[strlen(str) - 1] = '\0';
 
-		connman_error("CLAT %s: %s", clat_settings.tayga_bin, str);
+		connman_info("CLAT %s: %s", clat_settings.tayga_bin, str);
 
 		g_free(str);
 	} else if (condition & (G_IO_ERR | G_IO_HUP)) {
@@ -1395,7 +1407,8 @@ static void setup_double_nat(struct clat_data *data)
 	if (!data)
 		return;
 
-	if (data->tethering_on && data->state == CLAT_STATE_RUNNING) {
+	if (data->tethering == TETHERING_ON &&
+					data->state == CLAT_STATE_RUNNING) {
 		DBG("tethering enabled when CLAT is running, override nat");
 
 		err = connman_nat_enable_double_nat_override(TAYGA_CLAT_DEVICE,
@@ -1403,7 +1416,7 @@ static void setup_double_nat(struct clat_data *data)
 						CLAT_IPv4ADDR_NETMASK);
 		if (err && err != -EINPROGRESS)
 			connman_error("Failed to setup double nat for tether");
-	} else {
+	} else if (data->tethering == TETHERING_OFF) {
 		DBG("Remove nat override");
 		connman_nat_disable_double_nat_override(TAYGA_CLAT_DEVICE);
 	}
@@ -1411,6 +1424,8 @@ static void setup_double_nat(struct clat_data *data)
 
 static void stop_running(struct clat_data *data)
 {
+	enum tethering_state tethering;
+
 	if (!data)
 		return;
 
@@ -1418,8 +1433,11 @@ static void stop_running(struct clat_data *data)
 	clat_task_stop_dad(data);
 	clat_task_stop_online_check(data);
 
-	data->tethering_on = false;
+	/* When stopping always disable double nat but backup tethering state */
+	tethering = data->tethering;
+	data->tethering = TETHERING_OFF;
 	setup_double_nat(data);
+	data->tethering = tethering;
 }
 
 static int clat_run_task(struct clat_data *data)
@@ -1573,6 +1591,9 @@ static int clat_stop(struct clat_data *data)
 		return -EALREADY;
 	}
 
+	if (data->state == CLAT_STATE_PREFIX_QUERY)
+		clat_task_stop_periodic_query(data);
+
 	if (data->task)
 		connman_task_stop(data->task);
 	else
@@ -1633,7 +1654,7 @@ static void clat_del_rtnl_gateway(int index, const char *dst,
 	/* We lost our gateway, shut down clat */
 	if (!g_strcmp0(data->isp_64gateway, gateway)) {
 		DBG("CLAT gateway %s gone", data->isp_64gateway);
-		clat_stop(data);
+		//clat_stop(data);
 	}
 }
 
@@ -1672,7 +1693,8 @@ static bool is_supported_service_type(struct connman_service *service)
 	return false;
 }
 
-static bool has_ipv4_address(struct connman_service *service)
+static bool has_ip_address(struct connman_service *service,
+						enum connman_ipconfig_type type)
 {
 	struct connman_ipconfig *ipconfig;
 	struct connman_ipaddress *ipaddress;
@@ -1680,30 +1702,43 @@ static bool has_ipv4_address(struct connman_service *service)
 	const char *address;
 	unsigned char prefixlen;
 	int err;
+	int v;
 
-	ipconfig = connman_service_get_ipconfig(service, AF_INET);
-	DBG("IPv4 ipconfig %p", ipconfig);
+	switch (type) {
+	case CONNMAN_IPCONFIG_TYPE_IPV4:
+		ipconfig = connman_service_get_ipconfig(service, AF_INET);
+		v = 4;
+		break;
+	case CONNMAN_IPCONFIG_TYPE_IPV6:
+		ipconfig = connman_service_get_ipconfig(service, AF_INET6);
+		v = 6;
+		break;
+	case CONNMAN_IPCONFIG_TYPE_ALL:
+	case CONNMAN_IPCONFIG_TYPE_UNKNOWN:
+		return false;
+	}
+
+	DBG("IPv%d ipconfig %p", v, ipconfig);
 
 	ipaddress = connman_ipconfig_get_ipaddress(ipconfig);
-	DBG("IPv4 ipaddress %p", ipaddress);
+	DBG("IPv%d ipaddress %p", v, ipaddress);
 
 	err = connman_ipaddress_get_ip(ipaddress, &address, &prefixlen);
 	if (err) {
-		DBG("IPv4 is not configured on service %p", service);
+		DBG("IPv%d is not configured on service %p", v, service);
 		return false;
 	}
 
 	if (!address) {
-		DBG("no IPv4 address on service %p", service);
+		DBG("no IPv%d address on service %p", v, service);
 		return false;
 	}
 
-	method = connman_service_get_ipconfig_method(service,
-						CONNMAN_IPCONFIG_TYPE_IPV4);
+	method = connman_service_get_ipconfig_method(service, type);
 	switch (method) {
 	case CONNMAN_IPCONFIG_METHOD_UNKNOWN:
 	case CONNMAN_IPCONFIG_METHOD_OFF:
-		DBG("IPv4 method unknown/off, address is old");
+		DBG("IPv%d method unknown/off, address is old", v);
 		return false;
 	case CONNMAN_IPCONFIG_METHOD_FIXED:
 	case CONNMAN_IPCONFIG_METHOD_MANUAL:
@@ -1712,7 +1747,7 @@ static bool has_ipv4_address(struct connman_service *service)
 		break;
 	}
 
-	DBG("IPv4 address %s set for service %p", address, service);
+	DBG("IPv%d address %s set for service %p", v, address, service);
 	return true;
 }
 
@@ -1741,6 +1776,11 @@ static int try_clat_start(struct clat_data *data)
 		return -ENONET;
 	}
 
+	if (!connman_network_get_connected(network)) {
+		DBG("Network not connected yet, not starting clat");
+		return -ENONET;
+	}
+
 	if (data->ifindex < 0) {
 		DBG("ifindex not set, get it from network");
 		data->ifindex = connman_network_get_index(network);
@@ -1763,7 +1803,8 @@ static int try_clat_start(struct clat_data *data)
 	/* Network may have DHCP/AUTO set without address */
 	if (connman_network_is_configured(network,
 					CONNMAN_IPCONFIG_TYPE_IPV4) &&
-					has_ipv4_address(data->service)) {
+					has_ip_address(data->service, 
+						CONNMAN_IPCONFIG_TYPE_IPV4)) {
 		DBG("Service %p has IPv4 address on interface %d, not "
 						"starting CLAT", data->service,
 						data->ifindex);
@@ -1778,12 +1819,11 @@ static void clat_ipconfig_changed(struct connman_service *service,
 {
 	struct connman_network *network;
 	struct clat_data *data = get_data();
-	int err;
-
-	if (service || !data->service)
-		return;
 
 	DBG("service %p ipconfig %p", service, ipconfig);
+
+	if (!service || !data->service)
+		return;
 
 	/* TODO Support VPN as well */
 	if (service != data->service || !is_supported_service_type(service)) {
@@ -1793,9 +1833,23 @@ static void clat_ipconfig_changed(struct connman_service *service,
 	}
 
 	if (connman_ipconfig_get_config_type(ipconfig) ==
-						CONNMAN_IPCONFIG_TYPE_IPV4 &&
-						has_ipv4_address(service)) {
+					CONNMAN_IPCONFIG_TYPE_IPV4 &&
+					has_ip_address(service,
+						CONNMAN_IPCONFIG_TYPE_IPV4)) {
 		DBG("cellular %p has IPv4 config, stop CLAT", service);
+		clat_stop(data);
+		return;
+	}
+
+	/*
+	 * When service loses its IPv6 address we need to stop. When service
+	 * goes offline ipconfig may have been removed.
+	 */
+	if ((connman_ipconfig_get_config_type(ipconfig) ==
+					CONNMAN_IPCONFIG_TYPE_IPV6) &&
+					!has_ip_address(service,
+						CONNMAN_IPCONFIG_TYPE_IPV6)) {
+		DBG("cellular %p has lost IPv6 config, stop CLAT", service);
 		clat_stop(data);
 		return;
 	}
@@ -1813,13 +1867,6 @@ static void clat_ipconfig_changed(struct connman_service *service,
 		clat_stop(data);
 		return;
 	}
-
-	if (is_valid_start_state(connman_service_get_state(data->service))) {
-		DBG("service %p ready|online, start CLAT", data->service);
-		err = try_clat_start(data);
-		if (err && err != -EALREADY)
-			connman_error("CLAT failed to start, error %d", err);
-	}
 }
 
 static void clat_default_changed(struct connman_service *service)
@@ -1827,6 +1874,7 @@ static void clat_default_changed(struct connman_service *service)
 	struct connman_network *network;
 	struct clat_data *data;
 	enum connman_service_state state;
+	enum connman_ipconfig_type type = CONNMAN_IPCONFIG_TYPE_IPV4;
 	int err;
 
 	if (!service)
@@ -1870,9 +1918,8 @@ static void clat_default_changed(struct connman_service *service)
 		return;
 	}
 
-	if (connman_network_is_configured(network,
-					CONNMAN_IPCONFIG_TYPE_IPV4) &&
-					has_ipv4_address(data->service)) {
+	if (connman_network_is_configured(network, type) &&
+					has_ip_address(data->service, type)) {
 		DBG("IPv4 is configured on network %p, stop CLAT",
 							network);
 		clat_stop(data);
@@ -1970,7 +2017,7 @@ static void clat_tethering_changed(struct connman_technology *tech, bool on)
 	struct clat_data *data = get_data();
 
 	/* We just need to know if tethering is enabled or not */
-	data->tethering_on = on;
+	data->tethering = on ? TETHERING_ON : TETHERING_OFF;
 
 	setup_double_nat(data);
 }

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -88,6 +88,7 @@ struct clat_data {
 
 	enum tethering_state tethering;
 	bool do_restart;
+	bool task_is_stopping;
 };
 
 #define WKN_ADDRESS "ipv4only.arpa"
@@ -463,6 +464,30 @@ static int create_task(struct clat_data *data)
 	return 0;
 }
 
+static int stop_task(struct clat_data *data)
+{
+	int err;
+
+	if (!data || !data->task)
+		return -ENOENT;
+
+	DBG("task %p", data->task);
+
+	/* Task should be called to stop only once */
+	if (data->task_is_stopping) {
+		DBG("already stopping");
+		return -EALREADY;
+	}
+
+	err = connman_task_stop(data->task);
+	if (err)
+		connman_error("CLAT failed to stop current task");
+	else
+		data->task_is_stopping = true;
+
+	return err;
+}
+
 static int destroy_task(struct clat_data *data)
 {
 	int err;
@@ -472,14 +497,13 @@ static int destroy_task(struct clat_data *data)
 
 	DBG("task %p", data->task);
 
-	err = connman_task_stop(data->task);
-	if (err) {
-		connman_error("CLAT failed to stop current task");
-		return err;
-	}
+	err = stop_task(data);
+	if (err && err != -EALREADY)
+		connman_error("CLAT task stopping failed, continuing anyway");
 
 	connman_task_destroy(data->task);
 	data->task = NULL;
+
 	return 0;
 }
 
@@ -1448,6 +1472,9 @@ static void clat_task_exit(struct connman_task *task, int exit_code,
 
 	destroy_task(data);
 
+	/* Reset task stopping after destroy to avoid 2nd call */
+	data->task_is_stopping = false;
+
 	switch (data->state) {
 	case CLAT_STATE_IDLE:
 	case CLAT_STATE_STOPPED:
@@ -1622,8 +1649,10 @@ static int clat_run_task(struct clat_data *data)
 				 */
 				data->do_restart = false;
 				data->state = CLAT_STATE_PREFIX_QUERY;
-				if (data->task)
-					connman_task_stop(data->task);
+				err = stop_task(data);
+				if (err)
+					DBG("Failed to stop task %p, continue",
+								data->task);
 
 				return 0;
 			} else {
@@ -1725,9 +1754,9 @@ static int clat_stop(struct clat_data *data)
 		clat_task_stop_periodic_query(data);
 
 	if (data->task)
-		connman_task_stop(data->task);
-	else
-		data->state = CLAT_STATE_STOPPED;
+		return stop_task(data);
+
+	data->state = CLAT_STATE_STOPPED;
 
 	return 0;
 }

--- a/connman/plugins/clat.c
+++ b/connman/plugins/clat.c
@@ -1286,37 +1286,50 @@ void clat_dad_cb(struct nd_neighbor_advert *reply, unsigned int length,
 					struct in6_addr *addr,
 					void *user_data)
 {
-	char ipv6_addr[INET6_ADDRSTRLEN];
+	char ipv6_addr[INET6_ADDRSTRLEN] = { 0 };
 
-	// This reply can be ignored
-	DBG("got reply %p length %u", reply, length);
+	DBG("reply %p length %u", reply, length);
 
-	if (addr && inet_ntop(AF_INET6, addr, ipv6_addr, INET6_ADDRSTRLEN))
-		DBG("IPv6 address %s", ipv6_addr);
+	if (addr) {
+		/* This should not probably happen */
+		if (!inet_ntop(AF_INET6, addr, ipv6_addr, INET6_ADDRSTRLEN)) {
+			DBG("Invalid IPv6 address in DAD reply");
+		}
+	}
 
-	return;
+	/* No reply with zero lenght means success according to dhcpv6.c */
+	if (!reply && !length) {
+		DBG("DAD succeeded for %s", ipv6_addr);
+		return;
+	}
+
+	/* TODO select another address if cannot be DAD'd and restart process */
+	DBG("DAD failed for %s", ipv6_addr);
 }
 
 static gboolean clat_task_run_dad(gpointer user_data)
 {
 	struct clat_data *data = user_data;
-	unsigned char addr[sizeof(struct in6_addr)];
-	int err = 0;
+	struct in6_addr addr = { 0 };
+	int err;
 
 	DBG("data %p", data);
 
 	data->dad_id = 0;
 
-	if (inet_pton(AF_INET6, data->address, addr) != 1) {
+	if (inet_pton(AF_INET6, data->address, &addr) != 1) {
 		connman_error("failed to pton address %s", data->address);
 		return G_SOURCE_REMOVE;
 	}
 
-	err = connman_inet_ipv6_do_dad(data->ifindex, 100,
-						(struct in6_addr *)addr,
-						clat_dad_cb, data);
-	if (err) {
-		connman_error("CLAT failed to send dad: %d", err);
+	err = connman_inet_ipv6_do_dad(data->ifindex, 1000, &addr, clat_dad_cb,
+									data);
+	if (err < 0) {
+		/*
+		 * If the sending of DAD fails consecutive calls will as well,
+		 * stop DAD in such case
+		 */
+		connman_error("CLAT failed to send DAD: %d, stoppped", err);
 		return G_SOURCE_REMOVE;
 	}
 

--- a/connman/plugins/sailfish_ofono.c
+++ b/connman/plugins/sailfish_ofono.c
@@ -665,15 +665,19 @@ static void modem_ipaddress_setup(struct modem_data *md)
 		DBG("IPv4 only, set IPv6 off");
 		service = connman_service_lookup_from_network(md->network);
 		ipconfig = connman_service_get_ipconfig(service, AF_INET6);
-		connman_network_set_ipv6_method(md->network,
-						CONNMAN_IPCONFIG_METHOD_OFF);
+		/* This may interfere with ofono
+		 * connman_network_set_ipv6_method(md->network,
+		 * 				CONNMAN_IPCONFIG_METHOD_OFF);
+		 */
 		break;
 	case OFONO_CONNCTX_PROTOCOL_IPV6:
 		DBG("IPv6 only, set IPv4 off");
 		service = connman_service_lookup_from_network(md->network);
 		ipconfig = connman_service_get_ipconfig(service, AF_INET);
-		connman_network_set_ipv4_method(md->network,
-						CONNMAN_IPCONFIG_METHOD_OFF);
+		/* This may interfere with ofono
+		 * connman_network_set_ipv4_method(md->network,
+		 * 				CONNMAN_IPCONFIG_METHOD_OFF);
+		 */
 		break;
 	case OFONO_CONNCTX_PROTOCOL_DUAL:
 	case OFONO_CONNCTX_PROTOCOL_NONE:

--- a/connman/plugins/sailfish_ofono.c
+++ b/connman/plugins/sailfish_ofono.c
@@ -651,6 +651,40 @@ static gboolean modem_is_network_configured(struct modem_data *md)
 	return TRUE;
 }
 
+static void modem_ipaddress_setup(struct modem_data *md)
+{
+	struct connman_service *service;
+	struct connman_ipconfig *ipconfig = NULL;
+	struct connman_ipaddress *ipaddress;
+
+	if (!md)
+		return;
+
+	switch (md->connctx->protocol) {
+	case OFONO_CONNCTX_PROTOCOL_IP:
+		DBG("IPv4 only, set IPv6 off");
+		service = connman_service_lookup_from_network(md->network);
+		ipconfig = connman_service_get_ipconfig(service, AF_INET6);
+		connman_network_set_ipv6_method(md->network,
+						CONNMAN_IPCONFIG_METHOD_OFF);
+		break;
+	case OFONO_CONNCTX_PROTOCOL_IPV6:
+		DBG("IPv6 only, set IPv4 off");
+		service = connman_service_lookup_from_network(md->network);
+		ipconfig = connman_service_get_ipconfig(service, AF_INET);
+		connman_network_set_ipv4_method(md->network,
+						CONNMAN_IPCONFIG_METHOD_OFF);
+		break;
+	case OFONO_CONNCTX_PROTOCOL_DUAL:
+	case OFONO_CONNCTX_PROTOCOL_NONE:
+	case OFONO_CONNCTX_PROTOCOL_UNKNOWN:
+		return;
+	}
+
+	ipaddress = connman_ipconfig_get_ipaddress(ipconfig);
+	connman_ipaddress_clear(ipaddress);
+}
+
 static void modem_ensure_dual_mode_configuration(struct modem_data *md)
 {
 	bool ipv4_configured;
@@ -705,6 +739,7 @@ static gboolean modem_delayed_set_connected(gpointer data)
 		modem_ensure_dual_mode_configuration(md);
 
 	connman_network_set_connected(md->network, TRUE);
+	modem_ipaddress_setup(md);
 
 	md->delayed_set_connected_id = 0;
 	md->delayed_set_connected_attempts = 0;
@@ -728,6 +763,7 @@ static void modem_set_connected(struct modem_data *md)
 
 	if (modem_is_network_configured(md)) {
 		connman_network_set_connected(md->network, TRUE);
+		modem_ipaddress_setup(md);
 	} else {
 		DBG("%p init delayed connect, modem network not ready", md);
 

--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -260,6 +260,11 @@ int __connman_inet_del_default_from_table(uint32_t table_id, int ifindex, const 
 int __connman_inet_get_address_netmask(int ifindex,
 		struct sockaddr_in *address, struct sockaddr_in *netmask);
 
+int __connman_inet_add_ipv6_neigbour_proxy(int index, const char *ipv6_address,
+						unsigned char ipv6_prefixlen);
+int __connman_inet_del_ipv6_neigbour_proxy(int index, const char *ipv6_address,
+						unsigned char ipv6_prefixlen);
+
 #include <connman/resolver.h>
 
 int __connman_resolver_init(gboolean dnsproxy);

--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -539,6 +539,12 @@ void __connman_ipconfig_ipv6_set_force_disabled(
 					bool force_disabled);
 bool __connman_ipconfig_ipv6_get_force_disabled(
 					struct connman_ipconfig *ipconfig);
+int __connman_ipconfig_ipv6_get_accept_ra(struct connman_ipconfig *ipconfig);
+int __connman_ipconfig_ipv6_set_accept_ra(struct connman_ipconfig *ipconfig,
+					int value);
+bool __connman_ipconfig_ipv6_get_ndproxy(struct connman_ipconfig *ipconfig);
+int __connman_ipconfig_ipv6_set_ndproxy(struct connman_ipconfig *ipconfig,
+					bool enable);
 
 int __connman_ipconfig_set_rp_filter();
 void __connman_ipconfig_unset_rp_filter(int old_value);

--- a/connman/src/inet.c
+++ b/connman/src/inet.c
@@ -778,8 +778,11 @@ int connman_inet_add_ipv6_network_route_with_metric(int index, const char *host,
 
 	rt.rtmsg_flags = RTF_UP;
 
-	/* Add host flag for route only when not setting a default route. */
-	if (!__connman_inet_is_any_addr(host, AF_INET6))
+	/*
+	 * Add host flag for route only when not setting a default route and
+	 * the route is not to a single IPv6 host address.
+	 */
+	if (!__connman_inet_is_any_addr(host, AF_INET6) && metric < 128)
 		rt.rtmsg_flags |= RTF_HOST;
 
 	/*

--- a/connman/src/inet.c
+++ b/connman/src/inet.c
@@ -47,6 +47,8 @@
 #include <ctype.h>
 #include <ifaddrs.h>
 #include <linux/fib_rules.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
 
 #include "connman.h"
 #include <gdhcp/gdhcp.h>
@@ -3266,4 +3268,90 @@ int __connman_inet_get_address_netmask(int ifindex,
 out:
 	close(sk);
 	return ret;
+}
+
+static int ipv6_neigbour_proxy(int index, bool enable, const char *ipv6_address,
+						unsigned char ipv6_prefixlen)
+{
+	struct sockaddr_nl nladdr;
+	struct nlmsghdr *nlh;
+	struct ndmsg *ndm;
+	struct rtattr *attr;
+	char buf[4096] = { 0 };
+	ssize_t len;
+	int sk;
+	int err = -EINVAL;
+
+	if (index < 0 || !ipv6_address)
+		return -EINVAL;
+
+	sk = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+	if (sk < 0)
+		goto out;
+
+	memset(&nladdr, 0, sizeof(nladdr));
+	nladdr.nl_family = AF_NETLINK;
+
+	nlh = (struct nlmsghdr *)buf;
+	nlh->nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
+	nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_EXCL;
+	nlh->nlmsg_type = enable ? RTM_NEWNEIGH : RTM_DELNEIGH;
+
+	ndm = (struct ndmsg *)NLMSG_DATA(nlh);
+	ndm->ndm_family = AF_INET6;
+	ndm->ndm_state = NUD_PERMANENT;
+	ndm->ndm_ifindex = index;
+	ndm->ndm_type = RTN_UNICAST;
+	ndm->ndm_flags = NTF_PROXY;
+
+	attr = (struct rtattr *)(buf + NLMSG_ALIGN(nlh->nlmsg_len));
+	attr->rta_type = NDA_DST;
+	attr->rta_len = RTA_LENGTH(sizeof(struct in6_addr));
+
+	if (!inet_pton(AF_INET6, ipv6_address, RTA_DATA(attr))) {
+		connman_error("Invalid ndproxy IPv6 address %s", ipv6_address);
+		goto out;
+	}
+
+	nlh->nlmsg_len = NLMSG_ALIGN(nlh->nlmsg_len) +
+					RTA_LENGTH(sizeof(struct in6_addr));
+
+	len = sendto(sk, nlh, nlh->nlmsg_len, 0, (struct sockaddr *) &nladdr,
+							sizeof(nladdr));
+	if (len == -1) {
+		connman_error("neighbour proxy %s request failed: %d/%s",
+							enable ? "add" : "del",
+							-errno,
+							strerror(errno));
+		err = -errno;
+		goto out;
+	}
+
+	if ((unsigned int)len != nlh->nlmsg_len) {
+		connman_error("Sent %d bytes, msg truncated", err);
+		goto out;
+	}
+
+	err = 0;
+
+out:
+	close(sk);
+
+	return err;
+}
+
+int __connman_inet_add_ipv6_neigbour_proxy(int index, const char *ipv6_address,
+						unsigned char ipv6_prefixlen)
+{
+	DBG("index %d IPv6 address %s", index, ipv6_address);
+
+	return ipv6_neigbour_proxy(index, true, ipv6_address, ipv6_prefixlen);
+}
+
+int __connman_inet_del_ipv6_neigbour_proxy(int index, const char *ipv6_address,
+						unsigned char ipv6_prefixlen)
+{
+	DBG("index %d IPv6 address %s", index, ipv6_address);
+
+	return ipv6_neigbour_proxy(index, false, ipv6_address, ipv6_prefixlen);
 }

--- a/connman/src/inet.c
+++ b/connman/src/inet.c
@@ -2223,6 +2223,16 @@ int __connman_inet_ipv6_do_dad(int index, int timeout_ms,
 	return err;
 }
 
+int connman_inet_ipv6_do_dad(int index, int timeout_ms,
+				struct in6_addr *addr,
+				connman_inet_ns_cb_t callback,
+				void *user_data)
+{
+	return __connman_inet_ipv6_do_dad(index, timeout_ms, addr,
+					(__connman_inet_ns_cb_t)callback,
+					user_data);
+}
+
 GSList *__connman_inet_ipv6_get_prefixes(struct nd_router_advert *hdr,
 					unsigned int length)
 {

--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -443,6 +443,52 @@ static int set_rp_filter(int value)
 	return write_ipv4_conf_value(NULL, "rp_filter", value);
 }
 
+static int set_ipv6_accept_ra(gchar *ifname, int value)
+{
+	switch (value) {
+	case -1:
+		value = 0;
+		/* fall through */
+	case 0:
+	case 1:
+	case 2:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return write_ipv6_conf_value(ifname, "accept_ra", value);
+}
+
+static int get_ipv6_accept_ra(gchar *ifname)
+{
+	int value;
+
+	if (read_ipv6_conf_value(ifname, "accept_ra", &value) < 0)
+		value = -EINVAL;
+
+	return value;
+}
+
+static int set_ipv6_ndproxy(gchar *ifname, bool enable)
+{
+	int value = enable ? 1 : 0;
+
+	DBG("%s %d", ifname, enable);
+
+	return write_ipv6_conf_value(ifname, "proxy_ndp", value);
+}
+
+static int get_ipv6_ndproxy(gchar *ifname)
+{
+	int value;
+
+	if (read_ipv6_conf_value(ifname, "proxy_ndp", &value) < 0)
+		value = -EINVAL;
+
+	return value;
+}
+
 int __connman_ipconfig_set_rp_filter()
 {
 	int value;
@@ -1169,6 +1215,15 @@ const char *__connman_ipconfig_get_gateway_from_index(int index,
 	return NULL;
 }
 
+struct connman_ipaddress *connman_ipconfig_get_ipaddress(
+					struct connman_ipconfig *ipconfig)
+{
+	if (!ipconfig)
+		return NULL;
+	
+	return ipconfig->address;
+}
+
 void __connman_ipconfig_set_index(struct connman_ipconfig *ipconfig, int index)
 {
 	ipconfig->index = index;
@@ -1815,6 +1870,86 @@ bool __connman_ipconfig_get_ipv6_support()
 {
 	return is_ipv6_supported;
 }
+
+int __connman_ipconfig_ipv6_get_accept_ra(struct connman_ipconfig *ipconfig)
+{
+	char *ifname;
+	int value;
+
+	if (!ipconfig || ipconfig->type != CONNMAN_IPCONFIG_TYPE_IPV6)
+		return -EINVAL;
+
+	ifname = connman_inet_ifname(ipconfig->index);
+	if (!ifname)
+		return -ENOENT;
+
+	value = get_ipv6_accept_ra(ifname);
+	g_free(ifname);
+
+	return value;
+}
+
+int __connman_ipconfig_ipv6_set_accept_ra(struct connman_ipconfig *ipconfig,
+								int value)
+{
+	char *ifname;
+	int err = 0;
+
+	if (!ipconfig || ipconfig->type != CONNMAN_IPCONFIG_TYPE_IPV6)
+		return -EINVAL;
+
+	ifname = connman_inet_ifname(ipconfig->index);
+	if (!ifname)
+		return -ENOENT;
+
+	/* Returns the amount of chars written */
+	if (set_ipv6_accept_ra(ifname, value) != 1)
+		err = -EPERM;
+
+	g_free(ifname);
+
+	return err;
+}
+
+bool __connman_ipconfig_ipv6_get_ndproxy(struct connman_ipconfig *ipconfig)
+{
+	char *ifname;
+	int value;
+
+	if (!ipconfig)
+		return false;
+
+	ifname = connman_inet_ifname(ipconfig->index);
+	if (!ifname)
+		return false;
+
+	value = get_ipv6_ndproxy(ifname);
+	g_free(ifname);
+
+	return value == 1 ? true : false;
+}
+
+int __connman_ipconfig_ipv6_set_ndproxy(struct connman_ipconfig *ipconfig,
+								bool enable)
+{
+	char *ifname;
+	int err = 0;
+
+	if (!ipconfig)
+		return -EINVAL;
+
+	ifname = connman_inet_ifname(ipconfig->index);
+	if (!ifname)
+		return -ENOENT;
+
+	if (set_ipv6_ndproxy(ifname, enable) != 1)
+		err = -EPERM;
+
+	g_free(ifname);
+
+	return err;
+}
+
 
 bool __connman_ipconfig_is_usable(struct connman_ipconfig *ipconfig)
 {

--- a/connman/src/nat.c
+++ b/connman/src/nat.c
@@ -30,25 +30,52 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <connman/ipconfig.h>
+
 #include "connman.h"
 
-static char *default_interface;
+static char *default_interface = NULL;
+static struct connman_service *default_service = NULL;
 static GHashTable *nat_hash;
 
 struct connman_nat {
+	int family;
+	char *ifname;			/* Same as the name as hash key */
 	char *address;
 	unsigned char prefixlen;
+	char *dst_address;
+	unsigned char dst_prefixlen;
 	struct firewall_context *fw;
+	int ipv6_accept_ra;
+	int ipv6_ndproxy;
+	char *ipv6_address;
+	unsigned char ipv6_prefixlen;
 
 	char *interface;
+	struct connman_ipconfig *ipv6config;
 };
 
-static int enable_ip_forward(bool enable)
+#define IPv4_FORWARD "/proc/sys/net/ipv4/ip_forward"
+#define IPv6_FORWARD "/proc/sys/net/ipv6/conf/all/forwarding"
+
+static int enable_ip_forward(int family, bool enable)
 {
+	const char *path;
 	static char value = 0;
 	int f, err = 0;
 
-	if ((f = open("/proc/sys/net/ipv4/ip_forward", O_CLOEXEC | O_RDWR)) < 0)
+	switch (family) {
+	case AF_INET:
+		path = IPv4_FORWARD;
+		break;
+	case AF_INET6:
+		path = IPv6_FORWARD;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if ((f = open(path, O_CLOEXEC | O_RDWR)) < 0)
 		return -errno;
 
 	if (!value) {
@@ -86,17 +113,32 @@ static int enable_nat(struct connman_nat *nat)
 	char *cmd;
 	int err;
 
-	g_free(nat->interface);
-	nat->interface = g_strdup(default_interface);
+	/* If the rule has dst_address set the interface is pre-defined */
+	if (!nat->dst_address) {
+		g_free(nat->interface);
+		nat->interface = g_strdup(default_interface);
+	}
 
 	if (!nat->interface)
 		return 0;
 
+	DBG("name %s interface %s", nat->ifname, nat->interface);
+
 	/* Enable masquerading */
-	cmd = g_strdup_printf("-s %s/%d -o %s -j MASQUERADE",
-					nat->address,
-					nat->prefixlen,
-					nat->interface);
+	if (!nat->dst_address)
+		cmd = g_strdup_printf("-s %s/%u -o %s -j MASQUERADE",
+						nat->address,
+						nat->prefixlen,
+						nat->interface);
+	else
+		cmd = g_strdup_printf("-s %s/%u -d %s/%u -o %s -j MASQUERADE",
+						nat->address,
+						nat->prefixlen,
+						nat->dst_address,
+						nat->dst_prefixlen,
+						nat->interface);
+
+	DBG("rule %s", cmd);
 
 	err = __connman_firewall_add_rule(nat->fw, NULL, NULL, "nat",
 				"POSTROUTING", cmd);
@@ -112,8 +154,30 @@ static void disable_nat(struct connman_nat *nat)
 	if (!nat->interface)
 		return;
 
+	DBG("interface %s", nat->interface);
+
 	/* Disable masquerading */
 	__connman_firewall_disable(nat->fw);
+}
+
+static void free_nat(struct connman_nat *nat)
+{
+	if (!nat)
+		return;
+
+	if (nat->fw)
+		__connman_firewall_destroy(nat->fw);
+
+	if (nat->ipv6config)
+		__connman_ipconfig_unref(nat->ipv6config);
+
+	g_free(nat->ifname);
+	g_free(nat->address);
+	g_free(nat->dst_address);
+	g_free(nat->ipv6_address);
+	g_free(nat->interface);
+
+	g_free(nat);
 }
 
 int __connman_nat_enable(const char *name, const char *address,
@@ -122,8 +186,10 @@ int __connman_nat_enable(const char *name, const char *address,
 	struct connman_nat *nat;
 	int err;
 
+	DBG("");
+
 	if (g_hash_table_size(nat_hash) == 0) {
-		err = enable_ip_forward(true);
+		err = enable_ip_forward(AF_INET, true);
 		if (err < 0)
 			return err;
 	}
@@ -138,20 +204,18 @@ int __connman_nat_enable(const char *name, const char *address,
 
 	nat->address = g_strdup(address);
 	nat->prefixlen = prefixlen;
+	nat->ifname = g_strdup(name);
+	nat->family = AF_INET;
 
 	g_hash_table_replace(nat_hash, g_strdup(name), nat);
 
 	return enable_nat(nat);
 
 err:
-	if (nat) {
-		if (nat->fw)
-			__connman_firewall_destroy(nat->fw);
-		g_free(nat);
-	}
+	free_nat(nat);
 
 	if (g_hash_table_size(nat_hash) == 0)
-		enable_ip_forward(false);
+		enable_ip_forward(AF_INET, false);
 
 	return -ENOMEM;
 }
@@ -164,20 +228,317 @@ void __connman_nat_disable(const char *name)
 	if (!nat)
 		return;
 
+	if (nat->family != AF_INET) {
+		DBG("nat %p/%s IP family is not IPv4", nat, name);
+		return;
+	}
+
 	disable_nat(nat);
 
 	g_hash_table_remove(nat_hash, name);
 
 	if (g_hash_table_size(nat_hash) == 0)
-		enable_ip_forward(false);
+		enable_ip_forward(AF_INET, false);
+}
+
+static void set_original_ipv6_values(struct connman_nat *nat)
+{
+	int index;
+	int err;
+
+	if (!nat || !nat->ipv6config)
+		return;
+
+	DBG("nat %p ipconfig %p", nat, nat->ipv6config);
+
+	err = enable_ip_forward(AF_INET6, false);
+	if (err)
+		connman_warn("Failed to disable IPv6 forwarding: %d", err);
+
+	if (nat->ipv6_accept_ra != -1)
+		__connman_ipconfig_ipv6_set_accept_ra(nat->ipv6config,
+					nat->ipv6_accept_ra);
+
+	if (nat->ipv6_ndproxy != -1) {
+		__connman_ipconfig_ipv6_set_ndproxy(nat->ipv6config,
+					nat->ipv6_ndproxy ? true : false);
+
+		index = __connman_ipconfig_get_index(nat->ipv6config);
+		if (index < 0)
+			return;
+
+		err = __connman_inet_del_ipv6_neigbour_proxy(index,
+					nat->ipv6_address,
+					nat->ipv6_prefixlen);
+		if (err) {
+			connman_error("failed to delete IPv6 neighbour proxy");
+			return;
+		}
+	}
+
+	DBG("done");
+}
+
+int connman_nat6_prepare(struct connman_ipconfig *ipconfig,
+						const char *ipv6_address,
+						unsigned char ipv6_prefixlen,
+						const char *ifname_in,
+						bool enable_ndproxy)
+{
+	struct connman_nat *nat;
+	char **rules = NULL;
+	int index;
+	int err;
+	int i;
+
+	DBG("ipconfig %p ifname_in %s enable_ndproxy %s", ipconfig, ifname_in,
+						enable_ndproxy ? "yes" : "no");
+
+	if (connman_ipconfig_get_config_type(ipconfig) !=
+						CONNMAN_IPCONFIG_TYPE_IPV6) {
+		DBG("ipconfig %p is not IPv6", ipconfig);
+		return -EINVAL;
+	}
+
+	nat = g_try_new0(struct connman_nat, 1);
+	if (!nat) {
+		connman_error("cannot create NAT struct");
+		return -ENOMEM;
+	}
+
+	nat->fw = __connman_firewall_create();
+	if (!nat->fw) {
+		connman_error("cannot create firewall");
+		g_free(nat);
+		return -ENOMEM;
+	}
+
+	nat->interface = g_strdup(ifname_in);
+	nat->family = AF_INET6;
+	nat->ipv6_accept_ra = -1;
+	nat->ipv6_ndproxy = -1;
+	nat->ipv6config = __connman_ipconfig_ref(ipconfig);
+	nat->ipv6_address = g_strdup(ipv6_address);
+	nat->ipv6_prefixlen = ipv6_prefixlen;
+
+	nat->ipv6_accept_ra = __connman_ipconfig_ipv6_get_accept_ra(
+							nat->ipv6config);
+
+	err = __connman_ipconfig_ipv6_set_accept_ra(nat->ipv6config, 2);
+	if (err) {
+		connman_error("failed to set accept_ra: %d", err);
+		goto err;
+	}
+
+	err = enable_ip_forward(AF_INET6, true);
+	if (err) {
+		connman_error("failed to set IPv6 forwarding: %d", err);
+		goto err;
+	}
+
+	index = __connman_ipconfig_get_index(nat->ipv6config);
+	nat->ifname = connman_inet_ifname(index);
+	if (!nat->ifname) {
+		connman_error("no interface name for index %d",
+					__connman_ipconfig_get_index(ipconfig));
+		goto err;
+	}
+
+	if (enable_ndproxy) {
+		DBG("Enabling ndproxy");
+
+		nat->ipv6_ndproxy = __connman_ipconfig_ipv6_get_ndproxy(
+							nat->ipv6config) ?
+								1 : 0;
+		err = __connman_ipconfig_ipv6_set_ndproxy(nat->ipv6config, true);
+		if (err) {
+			connman_error("failed to set IPv6 ndproxy");
+			goto err;
+		}
+
+		err = __connman_inet_add_ipv6_neigbour_proxy(index,
+							nat->ipv6_address,
+							nat->ipv6_prefixlen);
+		if (err) {
+			connman_error("failed to add IPv6 neighbour proxy");
+			goto err;
+		}
+	}
+
+	rules = g_new0(char*, 2);
+	rules[0] = g_strdup_printf("-i %s -o %s -j ACCEPT", nat->interface,
+								nat->ifname);
+	rules[1] = g_strdup_printf("-i %s -o %s -j ACCEPT", nat->ifname,
+								nat->interface);
+
+	for (i = 0; i < 2; i++) {
+		DBG("Enable firewall rule -I FORWARD %s", rules[i]);
+
+		/* Enable forward on IPv6 */
+		err = __connman_firewall_add_ipv6_rule(nat->fw, NULL, NULL,
+						"filter", "FORWARD", rules[i]);
+		if (err < 0) {
+			connman_error("Failed to set FORWARD rule %s on "
+						"ip6tables", rules[i]);
+			break;
+		}
+	}
+
+	g_strfreev(rules);
+
+	err = __connman_firewall_enable(nat->fw);
+	if (err < 0) {
+		connman_error("Failed to enable firewall");
+		goto err;
+	}
+
+	g_hash_table_replace(nat_hash, g_strdup(nat->ifname), nat);
+
+	DBG("prepare done");
+
+	return 0;
+
+err:
+	DBG("prepare failure, revert changes");
+
+	/* Restore original values */
+	set_original_ipv6_values(nat);
+	free_nat(nat);
+
+	return err;
+}
+
+void connman_nat6_restore(struct connman_ipconfig *ipconfig)
+{
+	struct connman_nat *nat;
+	char *ifname;
+
+	DBG("ipconfig %p", ipconfig);
+
+	if (!ipconfig)
+		return;
+
+	ifname = connman_inet_ifname(__connman_ipconfig_get_index(ipconfig));
+	if (!ifname) {
+		DBG("no interface name, cannot be removed");
+		return;
+	}
+
+	nat = g_hash_table_lookup(nat_hash, ifname);
+	if (!nat) {
+		DBG("no interface %s found in hash", ifname);
+		g_free(ifname);
+		return;
+	}
+
+	if (nat->family != AF_INET6) {
+		connman_error("nat %p/%s IP family is not IPv6", nat, ifname);
+		g_free(ifname);
+		return;
+	}
+
+	/* Restore original values */
+	set_original_ipv6_values(nat);
+
+	if (nat->fw) {
+		if (__connman_firewall_disable(nat->fw))
+			DBG("cannot disable firewall");
+	}
+
+	if (nat_hash)
+		g_hash_table_remove(nat_hash, ifname);
+
+	g_free(ifname);
+
+	DBG("restore done");
+}
+
+static int restart_nat()
+{
+	GHashTableIter iter;
+	gpointer key, value;
+	int count = 0;
+	int err;
+
+	DBG("");
+
+	g_hash_table_iter_init(&iter, nat_hash);
+
+	while (g_hash_table_iter_next(&iter, &key, &value)) {
+		const char *name = key;
+		struct connman_nat *nat = value;
+
+		if (nat->family != AF_INET)
+			continue;
+
+		DBG("name %s interface %s", name, nat->interface);
+
+		disable_nat(nat);
+		err = enable_nat(nat);
+		if (err < 0) {
+			DBG("Failed to enable nat for %s", name);
+			return err;
+		}
+
+		count++;
+	}
+
+	return 0;
+}
+
+int connman_nat_enable_double_nat_override(const char *ifname,
+						const char *ipaddr_range,
+						unsigned char ipaddr_prefixlen)
+{
+	struct connman_nat *nat;
+
+	if (!ifname || !ipaddr_range)
+		return -EINVAL;
+
+	DBG("interface %s", ifname);
+
+	g_free(default_interface);
+	default_interface = g_strdup(ifname);
+
+	nat = g_try_new0(struct connman_nat, 1);
+	if (!nat)
+		return -ENOMEM;
+
+	nat->fw = __connman_firewall_create();
+	if (!nat->fw) {
+		g_free(nat);
+		return -ENOMEM;
+	}
+
+	nat->address = g_strdup(ipaddr_range);
+	nat->prefixlen = ipaddr_prefixlen;
+	nat->dst_address = g_strdup(connman_setting_get_string(
+						"TetheringSubnetBlock"));
+	nat->dst_prefixlen = 24; /* Default by ippool.c */
+	nat->ifname = g_strdup(ifname);
+	nat->family = AF_INET;
+	/*
+	 * TODO the tether interface should be in main conf. As of now it is as
+	 * a define BRIDGE_NAME in tethering.c
+	 */
+	nat->interface = g_strdup("tether");
+
+	g_hash_table_replace(nat_hash, g_strdup(ifname), nat);
+
+	return restart_nat();
+}
+
+void connman_nat_disable_double_nat_override(const char *ifname)
+{
+	if (!ifname)
+		return;
+
+	__connman_nat_disable(ifname);
 }
 
 static void update_default_interface(struct connman_service *service)
 {
-	GHashTableIter iter;
-	gpointer key, value;
 	char *interface;
-	int err;
 
 	interface = connman_service_get_interface(service);
 
@@ -186,17 +547,15 @@ static void update_default_interface(struct connman_service *service)
 	g_free(default_interface);
 	default_interface = interface;
 
-	g_hash_table_iter_init(&iter, nat_hash);
-
-	while (g_hash_table_iter_next(&iter, &key, &value)) {
-		const char *name = key;
-		struct connman_nat *nat = value;
-
-		disable_nat(nat);
-		err = enable_nat(nat);
-		if (err < 0)
-			DBG("Failed to enable nat for %s", name);
+	if (default_service) {
+		connman_service_unref(default_service);
+		default_service = NULL;
 	}
+
+	if (service)
+		default_service = connman_service_ref(service);
+
+	restart_nat();
 }
 
 static void shutdown_nat(gpointer key, gpointer value, gpointer user_data)
@@ -210,10 +569,7 @@ static void cleanup_nat(gpointer data)
 {
 	struct connman_nat *nat = data;
 
-	__connman_firewall_destroy(nat->fw);
-	g_free(nat->address);
-	g_free(nat->interface);
-	g_free(nat);
+	free_nat(nat);
 }
 
 static struct connman_notifier nat_notifier = {
@@ -240,6 +596,10 @@ int __connman_nat_init(void)
 void __connman_nat_cleanup(void)
 {
 	DBG("");
+
+	g_free(default_interface);
+	if (default_service)
+		connman_service_unref(default_service);
 
 	g_hash_table_foreach(nat_hash, shutdown_nat, NULL);
 	g_hash_table_destroy(nat_hash);

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -7087,6 +7087,12 @@ __connman_service_get_ipconfig(struct connman_service *service, int family)
 
 }
 
+struct connman_ipconfig *connman_service_get_ipconfig(
+				struct connman_service *service, int family)
+{
+	return __connman_service_get_ipconfig(service, family);
+}
+
 enum connman_ipconfig_method connman_service_get_ipconfig_method(
 						struct connman_service *service,
 						enum connman_ipconfig_type type)

--- a/connman/tools/iptables-unit.c
+++ b/connman/tools/iptables-unit.c
@@ -147,6 +147,19 @@ struct connman_ipconfig *connman_service_get_ipconfig(
 	return NULL;
 }
 
+struct connman_ipconfig *
+__connman_ipconfig_ref_debug(struct connman_ipconfig *ipconfig,
+				const char *file, int line, const char *caller)
+{
+	return NULL;
+}
+
+void __connman_ipconfig_unref_debug(struct connman_ipconfig *ipconfig,
+				const char *file, int line, const char *caller)
+{
+	return;
+}
+
 struct connman_service *
 connman_service_ref_debug(struct connman_service *service,
 			const char *file, int line, const char *caller)

--- a/connman/tools/iptables-unit.c
+++ b/connman/tools/iptables-unit.c
@@ -134,6 +134,51 @@ struct connman_service *connman_service_lookup_from_identifier(
 	return NULL;
 }
 
+struct connman_network *connman_service_get_network(
+					struct connman_service *service)
+{
+	return NULL;
+}
+
+struct connman_ipconfig *connman_service_get_ipconfig(
+					struct connman_service *service,
+					int family)
+{
+	return NULL;
+}
+
+struct connman_service *
+connman_service_ref_debug(struct connman_service *service,
+			const char *file, int line, const char *caller)
+{
+	return NULL;
+}
+
+/**
+ * connman_service_unref:
+ * @service: service structure
+ *
+ * Decrease reference counter of service and release service if no
+ * longer needed.
+ */
+void connman_service_unref_debug(struct connman_service *service,
+			const char *file, int line, const char *caller)
+{
+	return;
+}
+
+bool connman_network_is_configured(struct connman_network *network,
+					enum connman_ipconfig_type type)
+{
+	g_assert(network);
+
+	if (type == CONNMAN_IPCONFIG_TYPE_IPV4 ||
+					type == CONNMAN_IPCONFIG_TYPE_IPV6)
+		return true;
+
+	return false;
+}
+
 const char *__connman_technology_get_tethering_ident(
 				struct connman_technology *tech)
 {
@@ -187,6 +232,11 @@ enum connman_service_state connman_service_get_state(
 						struct connman_service *service)
 {
 	return 0;
+}
+
+const char *connman_setting_get_string(const char *key)
+{
+	return NULL;
 }
 
 // DBus dummies
@@ -317,6 +367,63 @@ DBusMessage *g_dbus_create_reply(DBusMessage *message, int type, ...)
 	va_end(args);
 
 	return reply;
+}
+
+int __connman_ipconfig_ipv6_get_accept_ra(struct connman_ipconfig *ipconfig)
+{
+	return 0;
+}
+
+int __connman_ipconfig_ipv6_set_accept_ra(struct connman_ipconfig *ipconfig,
+								int value)
+{
+	return 0;
+}
+
+bool __connman_ipconfig_ipv6_get_forwarding(struct connman_ipconfig *ipconfig)
+{
+	return true;
+}
+
+int __connman_ipconfig_ipv6_set_forwarding(struct connman_ipconfig *ipconfig,
+								bool enable)
+{
+	return 0;
+}
+
+bool __connman_ipconfig_ipv6_get_ndproxy(struct connman_ipconfig *ipconfig)
+{
+	return true;
+}
+
+int __connman_ipconfig_ipv6_set_ndproxy(struct connman_ipconfig *ipconfig,
+								bool enable)
+{
+	return 0;
+}
+
+int __connman_ipconfig_get_index(struct connman_ipconfig *ipconfig)
+{
+	return 1;
+}
+
+struct connman_ipaddress *connman_ipconfig_get_ipaddress(
+					struct connman_ipconfig *ipconfig)
+{
+	return NULL;
+}
+
+enum connman_ipconfig_type connman_ipconfig_get_config_type(
+					struct connman_ipconfig *ipconfig)
+{
+	return CONNMAN_IPCONFIG_TYPE_UNKNOWN;
+}
+
+int connman_ipaddress_get_ip(struct connman_ipaddress *ipaddress,
+					const char **address,
+					unsigned char *netmask_prefix_length)
+{
+	return 0;
 }
 
 static guint watch_id = 69;

--- a/connman/unit/test-clat.c
+++ b/connman/unit/test-clat.c
@@ -772,6 +772,18 @@ struct connman_network *connman_service_get_network(
 	return service->network;
 }
 
+char **connman_service_get_nameservers(struct connman_service *service)
+{
+	char **nss = NULL;
+
+	nss = g_new0(char*, 2);
+	nss[0] = g_strdup("4.4.4.4");
+	nss[1] = g_strdup("8.8.8.8");
+	nss[2] = NULL;
+
+	return nss;
+}
+
 struct _GResolv {
 	int index;
 	GResolvResultFunc result_func;

--- a/connman/unit/test-clat.c
+++ b/connman/unit/test-clat.c
@@ -1,0 +1,4678 @@
+/*
+ *  ConnMan clat plugin unit tests
+ *
+ *  Copyright (C) 2023 Jolla Ltd. All rights reserved..
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <glib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <gdbus.h>
+
+#define CONNMAN_API_SUBJECT_TO_CHANGE
+#include "plugin.h"
+
+#include "src/connman.h"
+#include <gweb/gresolv.h>
+
+#define CLAT_DEV_INDEX 1
+#define CLAT_DEV_NAME "clat"
+#define SERVICE_DEV_INDEX 2
+#define SERVICE_DEV_NAME "if"
+
+extern struct connman_plugin_desc __connman_builtin_clat;
+
+/* Dummies */
+
+static bool __clat_dev_set = false;
+static bool __clat_dev_up = false;
+
+int connman_inet_ifup(int index)
+{
+	g_assert_cmpint(index, >, 0);
+
+	if (index == CLAT_DEV_INDEX && __clat_dev_set) {
+		if (__clat_dev_up)
+			return -EALREADY;
+
+		__clat_dev_up = true;
+		return 0;
+	}
+
+	return -ENODEV;
+}
+
+int connman_inet_ifdown(int index)
+{
+	g_assert_cmpint(index, >, 0);
+
+	if (index == CLAT_DEV_INDEX && __clat_dev_set) {
+		if (!__clat_dev_up)
+			return -EALREADY;
+
+		__clat_dev_up = false;
+		return 0;
+	}
+
+	return -ENODEV;
+}
+
+int connman_inet_rmtun(const char *ifname, int flags)
+{
+	g_assert_cmpstr(ifname, ==, CLAT_DEV_NAME);
+	g_assert_false(__clat_dev_up);
+	g_assert_true(__clat_dev_set);
+	__clat_dev_set = false;
+
+	return 0;
+}
+
+int connman_inet_mktun(const char *ifname, int flags)
+{
+	g_assert_cmpstr(ifname, ==, CLAT_DEV_NAME);
+	return 0;
+}
+
+int connman_inet_ifindex(const char *name)
+{
+	g_assert(name);
+
+	if (!g_strcmp0(name, CLAT_DEV_NAME) && __clat_dev_set)
+		return CLAT_DEV_INDEX;
+
+	if (g_str_has_prefix(name, SERVICE_DEV_NAME)) {
+		if (g_str_has_suffix(name, "2"))
+			return 2;
+		if (g_str_has_suffix(name, "3"))
+			return 3;
+	}
+
+	return -1;
+}
+
+char *connman_inet_ifname(int index)
+{
+	g_assert_cmpint(index, >, 0);
+
+	if (index == CLAT_DEV_INDEX && __clat_dev_set)
+		return g_strdup(CLAT_DEV_NAME);
+
+	if (index == SERVICE_DEV_INDEX || index == SERVICE_DEV_INDEX + 1)
+		return g_strdup_printf("%s%d", SERVICE_DEV_NAME, index);
+
+	return NULL;
+}
+
+int connman_inet_add_ipv6_network_route_with_metric(int index, const char *host,
+					const char *gateway,
+					unsigned char prefix_len, short metric)
+{
+	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
+	g_assert(host);
+
+	DBG("index %d host %s gateway %s prefix_len %u metric %d", index, host,
+						gateway, prefix_len, metric);
+	return 0;
+}
+
+int connman_inet_add_ipv6_network_route(int index, const char *host,
+					const char *gateway,
+					unsigned char prefix_len)
+{
+	return connman_inet_add_ipv6_network_route_with_metric(index, host,
+						gateway, prefix_len, 1);
+}
+
+int connman_inet_del_ipv6_network_route_with_metric(int index, const char *host,
+					unsigned char prefix_len, short metric)
+{
+	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
+	g_assert(host);
+
+	DBG("index %d host %s prefix_len %u metric %d", index, host,
+						prefix_len, metric);
+	return 0;
+}
+
+int connman_inet_del_ipv6_network_route(int index, const char *host,
+						unsigned char prefix_len)
+{
+	return connman_inet_del_ipv6_network_route_with_metric(index, host,
+						prefix_len, 1);
+}
+
+int connman_inet_set_address(int index, struct connman_ipaddress *ipaddress)
+{
+	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
+	g_assert(ipaddress);
+	return 0;
+}
+
+int connman_inet_add_host_route(int index, const char *host,
+						const char *gateway)
+{
+	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
+	g_assert(host);
+	return 0;
+}
+
+int connman_inet_add_network_route_with_metric(int index, const char *host,
+					const char *gateway,
+					const char *netmask, short metric,
+					unsigned long mtu)
+{
+	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
+	g_assert(host);
+	return 0;
+}
+
+int connman_inet_add_network_route(int index, const char *host,
+						const char *gateway,
+						const char *netmask)
+{
+	return connman_inet_add_network_route_with_metric(index, host,
+							gateway, netmask, 0, 0);
+}
+
+int connman_inet_del_host_route(int index, const char *host)
+{
+	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
+	g_assert(host);
+	return 0;
+}
+
+int connman_inet_del_network_route_with_metric(int index, const char *host,
+					short metric)
+{
+	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
+	g_assert(host);
+	return 0;
+}
+
+int connman_inet_del_network_route(int index, const char *host)
+{
+	return connman_inet_del_network_route_with_metric(index, host, 0);
+}
+
+int connman_inet_clear_address(int index, struct connman_ipaddress *ipaddress)
+{
+	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
+	g_assert(ipaddress);
+	return 0;
+}
+
+int connman_inet_check_ipaddress(const char *host)
+{
+	g_assert(host);
+	return 0;
+}
+
+static int dad_reply_ptr = 0x87654321;
+static connman_inet_ns_cb_t __dad_callback = NULL;
+static struct in6_addr dad_addr = { 0 };
+static void *__dad_user_data = NULL;
+
+int connman_inet_ipv6_do_dad(int index, int timeout_ms, struct in6_addr *addr,
+				connman_inet_ns_cb_t callback, void *user_data)
+{
+	g_assert_cmpint(index, ==, SERVICE_DEV_INDEX);
+	g_assert(addr);
+	g_assert(callback);
+
+	__dad_callback = callback;
+	memcpy(&dad_addr, addr, sizeof(struct in6_addr));
+	__dad_user_data = user_data;
+
+	return 0;
+}
+
+static bool __dad_succeeds = true;
+
+static bool call_dad_callback()
+{
+	struct nd_neighbor_advert *na = NULL;
+	unsigned int length = 0;
+
+	if (!__dad_callback)
+		return false;
+
+	if (!__dad_succeeds) {
+		na = (struct nd_neighbor_advert*)&dad_reply_ptr;
+		length = 1;
+	}
+
+	__dad_callback(na, length, &dad_addr, __dad_user_data);
+
+	__dad_callback = NULL;
+	__dad_user_data = NULL;
+
+	return true;
+}
+
+struct connman_task {
+	char *path;
+	GPtrArray *argv;
+	connman_task_exit_t exit_func;
+	void *exit_data;
+	bool running;
+};
+
+static struct connman_task *__task = NULL;
+static int __task_exit_value = 0;
+static int __task_run_count = 0;
+static char *__last_set_contents_write = NULL;
+static char *__last_set_contents = NULL;
+
+
+static void free_pointer(gpointer data, gpointer user_data)
+{
+	g_free(data);
+}
+
+static void free_task()
+{
+	g_free(__task->path);
+
+	if (__task->argv) {
+		g_ptr_array_foreach(__task->argv, free_pointer, NULL);
+		g_ptr_array_free(__task->argv, TRUE);
+	}
+
+	g_free(__task);
+	__task = NULL;
+}
+
+struct connman_task *connman_task_create(const char *program,
+					connman_task_setup_t custom_task_setup,
+					void *setup_data)
+{
+	g_assert(program);
+	g_assert_null(custom_task_setup);
+	g_assert_null(setup_data);
+
+	g_assert_true(g_str_has_suffix(program, "tayga"));
+
+	if (__task)
+		free_task();
+
+	__task = g_new0(struct connman_task, 1);
+	g_assert(__task);
+	
+	__task->path = g_strdup(program);
+	__task->argv = g_ptr_array_new();
+	__task->running = false;
+
+	return __task;
+}
+
+int connman_task_add_argument(struct connman_task *task,
+					const char *name,
+					const char *format, ...)
+{
+	g_assert(task);
+	g_assert(task == __task);
+	g_assert(name);
+
+	va_list ap;
+	char *str;
+
+	DBG("task %p arg %s", task, name);
+
+	str = g_strdup(name);
+	g_ptr_array_add(task->argv, str);
+
+	va_start(ap, format);
+
+	if (format) {
+		str = g_strdup_vprintf(format, ap);
+		g_ptr_array_add(task->argv, str);
+	}
+
+	va_end(ap);
+
+	return 0;
+}
+
+#define TASK_STDOUT 1
+#define TASK_STDERR 2
+
+int connman_task_run(struct connman_task *task,
+			connman_task_exit_t function, void *user_data,
+			int *stdin_fd, int *stdout_fd, int *stderr_fd)
+{
+	DBG("task %p function %p user_data %p", task, function, user_data);
+
+	g_assert(task);
+	g_assert(task == __task);
+
+	g_assert(function);
+	__task->exit_func = function;
+	__task->exit_data = user_data;
+	__task->running = true;
+	__task_run_count++;
+
+	if (stdout_fd)
+		*stdout_fd = TASK_STDOUT;
+
+	if (stderr_fd)
+		*stderr_fd = TASK_STDERR;
+
+	DBG("stdin %d stdout %d stderr %d", stdin_fd ? *stdin_fd : -1,
+					stdout_fd ? *stdout_fd : -1,
+					stderr_fd ? *stderr_fd : -1);
+
+	return 0;
+}
+
+int connman_task_stop(struct connman_task *task)
+{
+	connman_task_exit_t exit_func;
+	DBG("task %p", task);
+
+	g_assert(task);
+	g_assert(task == __task);
+
+	if (task->running) {
+		task->running = false;
+
+		/* Allow to run exit only once from a process */
+		exit_func = task->exit_func;
+		task->exit_func = NULL;
+
+		if (exit_func) {
+			exit_func(task, __task_exit_value, task->exit_data);
+		}
+	}
+
+	return 0;
+}
+
+void connman_task_destroy(struct connman_task *task)
+{
+	DBG("task %p", task);
+
+	g_assert(task);
+	g_assert(task == __task);
+
+	if (task->running)
+		connman_task_stop(task);
+
+	g_free(task->path);
+	task->path = NULL;
+
+	g_ptr_array_foreach(task->argv, free_pointer, NULL);
+	g_ptr_array_free(task->argv, TRUE);
+	task->argv = NULL;
+
+	/* don't free internal __task, that is cleared in test cleanup */
+
+	return;
+}
+
+enum task_setup {
+	TASK_SETUP_UNKNOWN = 0,
+	TASK_SETUP_PRE,
+	TASK_SETUP_CONF,
+	TASK_SETUP_POST,
+	TASK_SETUP_STOPPED,
+};
+
+static enum task_setup get_task_setup()
+{
+	g_assert(__task->path);
+
+	g_assert_true(g_ptr_array_find_with_equal_func(__task->argv, "--config",
+						g_str_equal, NULL));
+
+	if (g_ptr_array_find_with_equal_func(__task->argv, "--mktun",
+							g_str_equal, NULL)) {
+		__clat_dev_set = true;
+		return TASK_SETUP_PRE;
+	}
+
+	if (g_ptr_array_find_with_equal_func(__task->argv, "--rmtun",
+							g_str_equal, NULL)) {
+		__clat_dev_set = false;
+		return TASK_SETUP_POST;
+	}
+
+	if (g_ptr_array_find_with_equal_func(__task->argv, "--nodetach",
+							g_str_equal, NULL))
+		return TASK_SETUP_CONF;
+
+	return TASK_SETUP_UNKNOWN;
+}
+
+static void call_task_exit(int exit_code)
+{
+	DBG("exit_code %d", exit_code);
+
+	g_assert(__task->exit_func);
+	if (__task->running) {
+		__task->running = false;
+		__task->exit_func(__task, exit_code, __task->exit_data);
+	}
+}
+
+static gboolean task_running(enum task_setup setup, int add_run_count)
+{
+	if (!__task)
+		return false;
+
+	switch (setup) {
+	case TASK_SETUP_PRE:
+		g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_PRE);
+		g_assert_true(__clat_dev_set);
+		g_assert_false(__clat_dev_up);
+		g_assert_cmpint(__task_run_count, ==, 1 + add_run_count);
+		g_assert(__last_set_contents_write);
+		g_assert_true(g_str_has_suffix(__last_set_contents_write,
+								"tayga.conf"));
+		g_free(__last_set_contents_write);
+		__last_set_contents_write = NULL;
+		break;
+	case TASK_SETUP_CONF:
+		g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_CONF);
+		g_assert_true(__clat_dev_set);
+		g_assert_true(__clat_dev_up);
+		g_assert_cmpint(__task_run_count, ==, 2 + add_run_count);
+		g_assert_null(__last_set_contents_write);
+		break;
+	case TASK_SETUP_POST:
+		g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_POST);
+		g_assert_false(__clat_dev_set);
+		g_assert_false(__clat_dev_up);
+		g_assert_cmpint(__task_run_count, ==, 3 + add_run_count);
+		g_assert_null(__last_set_contents_write);
+		break;
+	case TASK_SETUP_STOPPED:
+		g_assert_cmpint(__task_run_count, ==, 3 + add_run_count);
+		g_assert_false(__clat_dev_set);
+		g_assert_false(__clat_dev_up);
+		g_assert_null(__last_set_contents_write);
+		return __task->running;
+	case TASK_SETUP_UNKNOWN:
+		/* No assert checks */
+		break;
+	}
+
+	return __task->path && __task->running;
+}
+
+static gboolean check_task_running(enum task_setup setup, int restarts)
+{
+	int add_run_count = restarts * 3;
+
+	DBG("setup %d restarts %d", setup, restarts);
+
+	return task_running(setup, add_run_count);
+}
+
+static gboolean check_task_running_added_rounds(enum task_setup setup,
+							int add_run_count)
+{
+	DBG("setup %d add %d rounds", setup, add_run_count);
+
+	return task_running(setup, add_run_count);
+}
+
+struct connman_ipconfig {
+	struct connman_ipaddress *ipaddress;
+	enum connman_ipconfig_type type;
+	enum connman_ipconfig_method method;
+};
+
+enum connman_ipconfig_type connman_ipconfig_get_config_type(
+					struct connman_ipconfig *ipconfig)
+{
+	DBG("ipconfig %p", ipconfig);
+
+	g_assert(ipconfig);
+
+	return ipconfig->type;
+}
+
+struct connman_ipaddress *connman_ipconfig_get_ipaddress(
+					struct connman_ipconfig *ipconfig)
+{
+	DBG("ipconfig %p", ipconfig);
+
+	g_assert(ipconfig);
+	return ipconfig->ipaddress;
+}
+
+enum connman_ipconfig_method get_method(struct connman_ipconfig *ipconfig)
+{
+	DBG("ipconfig %p", ipconfig);
+
+	g_assert(ipconfig);
+	return ipconfig->method;
+}
+
+static void assign_ipaddress(struct connman_ipconfig *ipconfig)
+{
+	switch (ipconfig->type) {
+	case CONNMAN_IPCONFIG_TYPE_IPV4:
+		ipconfig->ipaddress = connman_ipaddress_alloc(AF_INET);
+		connman_ipaddress_set_ipv4(ipconfig->ipaddress, "10.10.10.2",
+					"255.255.255.0", "10.10.10.1");
+		break;
+	case CONNMAN_IPCONFIG_TYPE_IPV6:
+		ipconfig->ipaddress = connman_ipaddress_alloc(AF_INET6);
+		connman_ipaddress_set_ipv6(ipconfig->ipaddress,
+					"dead:beef:feed:abba:caba:daba::1234",
+					64, NULL);
+		break;
+	default:
+		return;
+	}
+
+	g_assert(ipconfig->ipaddress);
+}
+
+int connman_nat_enable_double_nat_override(const char *ifname,
+						const char *ipaddr_range,
+						unsigned char ipaddr_netmask)
+{
+	DBG("interface %s ipaddr_range %s ipaddr_netmask %u", ifname,
+						ipaddr_range, ipaddr_netmask);
+	g_assert(ifname);
+	return 0;
+}
+
+void connman_nat_disable_double_nat_override(const char *ifname)
+{
+	g_assert(ifname);
+}
+
+int connman_nat6_prepare(struct connman_ipconfig *ipconfig,
+						const char *ipv6address,
+						unsigned char ipv6prefixlen,
+						const char *ifname_in,
+						bool ndproxy)
+{
+	g_assert(ipconfig);
+	return 0;
+}
+
+void connman_nat6_restore(struct connman_ipconfig *ipconfig)
+{
+	g_assert(ipconfig);
+}
+
+static struct connman_notifier *n;
+
+int connman_notifier_register(struct connman_notifier *notifier)
+{
+	g_assert(notifier);
+	g_assert_null(n);
+	n = notifier;
+	return 0;
+}
+
+void connman_notifier_unregister(struct connman_notifier *notifier)
+{
+	g_assert(notifier);
+	g_assert(notifier == n);
+	n = NULL;
+}
+
+struct connman_network {
+	int index;
+	bool connected;
+	bool ipv4_configured;
+	bool ipv6_configured;
+};
+
+int connman_network_get_index(struct connman_network *network)
+{
+	DBG("network %p", network);
+
+	g_assert(network);
+	DBG("index %d", network->index);
+	return network->index;
+}
+
+bool connman_network_get_connected(struct connman_network *network)
+{
+	DBG("network %p", network);
+
+	g_assert(network);
+	return network->connected;
+}
+
+bool connman_network_is_configured(struct connman_network *network,
+					enum connman_ipconfig_type type)
+{
+	DBG("network %p type %d", network, type);
+
+	g_assert(network);
+
+	switch (type) {
+	case CONNMAN_IPCONFIG_TYPE_UNKNOWN:
+		break;
+	case CONNMAN_IPCONFIG_TYPE_ALL:
+		return network->ipv4_configured && network->ipv6_configured;
+	case CONNMAN_IPCONFIG_TYPE_IPV4:
+		return network->ipv4_configured;
+	case CONNMAN_IPCONFIG_TYPE_IPV6:
+		return network->ipv6_configured;
+	default:
+		break;
+	}
+
+	return false;
+}
+
+struct connman_service {
+	char *identifier;
+	char *path;
+	enum connman_service_state state;
+	enum connman_service_type type;
+	char *name;
+	struct connman_ipconfig *ipconfig_ipv4;
+	struct connman_ipconfig *ipconfig_ipv6;
+	struct connman_network *network;
+};
+
+static struct connman_service *__def_service = NULL;
+
+struct connman_ipconfig *connman_service_get_ipconfig(
+					struct connman_service *service,
+					int family)
+{
+	DBG("service %p family %d", service, family);
+
+	g_assert(service);
+
+	if (family == AF_INET)
+		return service->ipconfig_ipv4;
+
+	if (family == AF_INET6)
+		return service->ipconfig_ipv6;
+
+	return NULL;
+}
+
+enum connman_ipconfig_method connman_service_get_ipconfig_method(
+					struct connman_service *service,
+					enum connman_ipconfig_type type)
+{
+	DBG("service %p type %d", service, type);
+
+	g_assert(service);
+
+	switch (type) {
+	case CONNMAN_IPCONFIG_TYPE_IPV4:
+		return get_method(service->ipconfig_ipv4);
+	case CONNMAN_IPCONFIG_TYPE_IPV6:
+		return get_method(service->ipconfig_ipv6);
+	case CONNMAN_IPCONFIG_TYPE_ALL:
+	case CONNMAN_IPCONFIG_TYPE_UNKNOWN:
+		break;
+	}
+
+	return CONNMAN_IPCONFIG_TYPE_UNKNOWN;
+}
+
+struct connman_service *connman_service_get_default(void)
+{
+	DBG("default %p", __def_service);
+
+	return __def_service;
+}
+
+const char *connman_service_get_identifier(struct connman_service *service)
+{
+	DBG("service %p", service);
+
+	g_assert(service);
+	return service->identifier;
+}
+
+
+enum connman_service_type connman_service_get_type(
+					struct connman_service *service)
+{
+	DBG("service %p", service);
+
+	g_assert(service);
+	return service->type;
+}
+
+enum connman_service_state connman_service_get_state(
+					struct connman_service *service)
+{
+	DBG("service %p", service);
+
+	g_assert(service);
+	return service->state;
+}
+
+struct connman_network *connman_service_get_network(
+					struct connman_service *service)
+{
+	DBG("service %p", service);
+
+	g_assert(service);
+	return service->network;
+}
+
+struct _GResolv {
+	int index;
+	GResolvResultFunc result_func;
+	gpointer result_data;
+	char *hostname;
+};
+
+static struct _GResolv *__resolv = NULL;
+
+GResolv *g_resolv_new(int index)
+{
+	DBG("index %d", index);
+	g_assert_cmpint(index, >= , 0);
+
+	g_assert_null(__resolv);
+	__resolv = g_new0(struct _GResolv, 1);
+	g_assert(__resolv);
+
+	__resolv->index = index;
+
+	return __resolv;
+}
+
+void g_resolv_unref(GResolv *resolv)
+{
+	DBG("resolv %p", resolv);
+
+	g_assert(resolv);
+	g_assert(resolv == __resolv);
+
+	g_free(__resolv->hostname);
+	g_free(__resolv);
+	__resolv = NULL;
+}
+
+static guint resolv_id = 0;
+
+guint g_resolv_lookup_hostname(GResolv *resolv, const char *hostname,
+				GResolvResultFunc func, gpointer user_data)
+{
+	DBG("resolv %p hostname %s func %p user_data %p", resolv, hostname,
+							func, user_data);
+
+	g_assert(resolv);
+	g_assert(resolv == __resolv);
+	g_assert(hostname);
+	g_assert(func);
+
+	g_assert_cmpstr(hostname, ==, "ipv4only.arpa");
+	__resolv->hostname = g_strdup(hostname);
+	__resolv->result_func = func;
+	__resolv->result_data = user_data;
+
+	return ++resolv_id;
+}
+
+bool g_resolv_cancel_lookup(GResolv *resolv, guint id)
+{
+	DBG("resolv %p id %d", resolv, id);
+	g_assert(resolv);
+	g_assert(resolv == __resolv);
+
+	g_assert_cmpint(id, ==, resolv_id);
+
+	g_free(__resolv->hostname);
+	__resolv->hostname = NULL;
+
+	return true;
+}
+
+bool g_resolv_set_address_family(GResolv *resolv, int family)
+{
+	DBG("resolv %p family %d", resolv, family);
+
+	g_assert(resolv);
+	g_assert(resolv == __resolv);
+	g_assert_cmpint(family, ==, AF_INET6);
+
+	return true;
+}
+
+enum resolv_result_type {
+	RESOLV_RESULT_GLOBAL = 0,
+	RESOLV_RESULT_ONE_64,
+	RESOLV_RESULT_ONE_96,
+	RESOLV_RESULT_SORT
+};
+
+static enum resolv_result_type __resolv_result_type = RESOLV_RESULT_GLOBAL;
+
+static void call_resolv_result(GResolvResultStatus status)
+{
+	/* TODO add more and make configurable */
+	char **r = g_new0(char*, 5);
+
+	switch (__resolv_result_type) {
+	case RESOLV_RESULT_GLOBAL:
+		r[0] = g_strdup("64:ff9b::c000:aa");
+		r[1] = g_strdup("64:ff9b::c000:ab");
+		r[2] = g_strdup("64:ff9b::/96");
+		r[3] = g_strdup("dead:beef:0000:feed:abba:cabb:1234:");
+		r[4] = NULL;
+		break;
+	case RESOLV_RESULT_ONE_64:
+		r[0] = g_strdup("66:ff9b::c000:aa");
+		r[1] = g_strdup("65:ff9b::c000:ab");
+		r[2] = g_strdup("63:ff9b::/96");
+		r[3] = g_strdup("dead:beef:0000:feed:abba:cabb:1234:5555/64");
+		break;
+	case RESOLV_RESULT_ONE_96:
+		r[0] = g_strdup("66:ff9b:c000:aa:aba:abab:baaa:aaaa");
+		r[1] = g_strdup("65:ff9b:c000:ab:1:2:3:4");
+		r[2] = g_strdup("63:ff9b::/64");
+		r[3] = g_strdup("dead:beef:0000:feed:abba:cabb:1234:5555/96");
+		break;
+	case RESOLV_RESULT_SORT:
+		r[0] = g_strdup("dead:beef:0000:feed:abba:cabb:1234:5556/64");
+		r[1] = g_strdup("dead:beef:0000:feed:abba:cabb:1234:5557/96");
+		r[2] = g_strdup("dead:beef:0000:feed:abba:cabb:1234:5558/72");
+		r[3] = g_strdup("dead:beef:0000:feed:abba:cabb:1234:5559/128");
+		break;
+	default:
+		break;
+	}
+	r[4] = NULL;
+
+	g_assert(__resolv);
+	g_assert(__resolv->hostname);
+	g_assert(__resolv->result_func);
+	g_assert(__resolv->result_data);
+
+	__resolv->result_func(status, r, __resolv->result_data);
+
+	g_strfreev(r);
+}
+
+static gboolean check_set_prefix()
+{
+	char **tokens;
+	char *addr;
+	bool result = true;
+	int i;
+
+	if (!__last_set_contents)
+		return false;
+
+	tokens = g_strsplit(__last_set_contents, "\n", 7);
+	if (!tokens)
+		return false;
+
+	for (i = 0; tokens[i]; i++) {
+		if (g_str_has_prefix(tokens[i], "prefix"))
+			break;
+	}
+
+	/* TODO make this better */
+	switch (__resolv_result_type) {
+	case RESOLV_RESULT_GLOBAL:
+		addr = g_strdup("prefix 64:ff9b::/96");
+		break;
+	case RESOLV_RESULT_ONE_64:
+		addr = g_strdup("prefix 63:ff9b::/96");
+		break;
+	case RESOLV_RESULT_ONE_96:
+		addr = g_strdup(
+			"prefix dead:beef:0000:feed:abba:cabb:1234:5555/96");
+		break;
+	case RESOLV_RESULT_SORT:
+		addr = g_strdup(
+			"prefix dead:beef:0000:feed:abba:cabb:1234:5557/96");
+		break;
+	default:
+		addr = NULL;
+	}
+
+	if (g_strcmp0(tokens[i], addr)) {
+		DBG("prefix %s is not expected %s", tokens[i], addr);
+		result = false;
+	}
+
+	g_strfreev(tokens);
+	g_free(addr);
+
+	return result;
+}
+
+gboolean g_file_set_contents(const gchar* filename, const gchar* contents,
+						gssize length, GError** error)
+{
+	DBG("filename %s", filename);
+
+	g_assert(filename);
+	g_assert(contents);
+
+	g_free(__last_set_contents_write);
+	__last_set_contents_write = g_strdup(filename);
+
+	g_free(__last_set_contents);
+	__last_set_contents = g_strdup(contents);
+
+	return TRUE;
+}
+
+// TODO config loading tests
+gboolean g_key_file_load_from_file(GKeyFile *keyfile, const gchar *file,
+					GKeyFileFlags flags, GError** error)
+{
+	g_assert(keyfile);
+	g_assert(file);
+
+	*error = g_error_new_literal(1, G_FILE_ERROR_NOENT, "no file in test");
+
+	return false;
+}
+
+static int stdout_fd_ch_ptr = 0x12345678;
+static int stderr_fd_ch_ptr = 0x12344321;
+
+static GIOFunc stdout_func = NULL;
+static GIOFunc stderr_func = NULL;
+static gpointer stdout_data = NULL;
+static gpointer stderr_data = NULL;
+
+struct timeout_function {
+	guint id; /* Only for debugs */
+	guint interval;
+	GSourceFunc function;
+	gpointer data;
+	bool removed;
+	bool called;
+};
+
+static GHashTable *__timeouts = NULL;
+
+static guint __timeout_id = 0;
+
+GIOChannel* g_io_channel_unix_new(int fd)
+{
+	//DBG("fd %d", fd);
+
+	g_assert_cmpint(fd, >, 0);
+
+	if (fd == TASK_STDOUT) {
+		stdout_fd_ch_ptr++;
+		return (GIOChannel *)&stdout_fd_ch_ptr;
+	}
+
+	if (fd == TASK_STDERR) {
+		stderr_fd_ch_ptr++;
+		return (GIOChannel *)&stderr_fd_ch_ptr;
+	}
+
+	return NULL;
+}
+
+/* Keep all source id's in the same place */
+static guint add_timeout(guint interval, GSourceFunc function, gpointer data)
+{	struct timeout_function *tf;
+
+	tf = g_new0(struct timeout_function, 1);
+	g_assert(tf);
+
+	tf->interval = interval;
+	tf->function = function;
+	tf->data = data;
+
+	if (!__timeouts) {
+		/* Uses guints to ptr */
+		__timeouts = g_hash_table_new_full(g_direct_hash,
+						g_direct_equal, NULL, g_free);
+		__timeout_id = 0;
+	}
+
+	__timeout_id++;
+	tf->id = __timeout_id;
+
+	g_hash_table_replace(__timeouts, GUINT_TO_POINTER(__timeout_id), tf);
+
+	return __timeout_id;
+
+}
+
+guint g_io_add_watch(GIOChannel* channel, GIOCondition condition, GIOFunc func,
+							gpointer user_data)
+{
+	//DBG("channel %p func %p user_data %p", channel, func, user_data);
+
+	g_assert(channel);
+	g_assert(func);
+
+	if (channel == (GIOChannel *)&stdout_fd_ch_ptr) {
+		stdout_func = func;
+		stdout_data = user_data;
+	}
+
+	if (channel == (GIOChannel *)&stderr_fd_ch_ptr) {
+		stderr_func = func;
+		stderr_data = user_data;
+	}
+
+	return add_timeout(0, NULL, user_data);
+}
+
+GIOStatus g_io_channel_shutdown(GIOChannel* channel, gboolean flush,
+								GError** error)
+{
+	//DBG("channel %p", channel);
+
+	if (channel == (GIOChannel *)&stdout_fd_ch_ptr ||
+				channel == (GIOChannel *)&stderr_fd_ch_ptr)
+		return G_IO_STATUS_NORMAL;
+
+	return G_IO_STATUS_ERROR;
+}
+
+static GIOStatus __io_status = G_IO_STATUS_NORMAL;
+static char *__io_str = NULL;
+
+GIOStatus g_io_channel_read_line(GIOChannel* channel, gchar** str_return,
+					gsize* length, gsize* terminator_pos,
+					GError** error)
+{
+	DBG("channel %p str %s", channel, __io_str);
+
+	g_assert(channel);
+	g_assert(str_return);
+
+	if (!__io_str)
+		return G_IO_STATUS_ERROR;
+
+	*str_return = g_strdup(__io_str);
+
+	return __io_status;
+}
+
+void g_io_channel_unref(GIOChannel* channel)
+{
+	//DBG("channel %p", channel);
+
+	if (channel == (GIOChannel *)&stdout_fd_ch_ptr) {
+		stdout_func = NULL;
+		stdout_data = NULL;
+	}
+
+	if (channel == (GIOChannel *)&stderr_fd_ch_ptr) {
+		stderr_func = NULL;
+		stderr_data = NULL;
+	}
+}
+
+static bool call_g_io_stderr(GIOCondition cond, const char *str)
+{
+	gboolean ret;
+
+	g_assert(stderr_func);
+
+	__io_str = g_strdup(str);
+	ret = stderr_func((GIOChannel *)&stderr_fd_ch_ptr, cond, stderr_data);
+
+	g_free(__io_str);
+	__io_str = NULL;
+
+	return ret;
+}
+
+gboolean g_source_remove(guint id)
+{
+	gpointer value;
+
+	DBG("id %u", id);
+
+	if (!__timeouts)
+		return false;
+
+	value = g_hash_table_lookup(__timeouts, GUINT_TO_POINTER(id));
+	if (value) {
+		struct timeout_function *tf = value;
+
+		DBG("found, marked as removed");
+		tf->removed = true;
+
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
+guint g_timeout_add(guint interval, GSourceFunc function, gpointer data)
+{
+	guint id;
+
+	g_assert(function);
+	g_assert(data);
+
+	id = add_timeout(interval, function, data);
+
+	DBG("added id %d", id);
+
+	return id;
+}
+
+guint connman_wakeup_timer_add(guint interval, GSourceFunc function,
+								gpointer data)
+{
+	return g_timeout_add(interval, function, data);
+}
+
+static bool call_timeout(gpointer key, gpointer value)
+{
+	struct timeout_function *tf;
+	guint id;
+
+	tf = value;
+	id = GPOINTER_TO_UINT(key);
+	if (!id)
+		id = tf->id;
+
+	if (tf->removed) {
+		DBG("id %u already removed, not calling callback", id);
+		return false;
+	}
+
+	if (tf->called) {
+		DBG("id %u already called", id);
+		return false;
+	}
+
+	g_assert(tf);
+
+	if (!tf->function) {
+		DBG("id %u does not have function (GIO)", id);
+		return false;
+	}
+
+	DBG("call id %u (interval %u)", id, tf->interval);
+
+	if (tf->function(tf->data) == G_SOURCE_REMOVE)
+		tf->removed = true;
+
+	tf->called = true;
+
+	return true;
+}
+
+static gint compare_uint(gconstpointer a, gconstpointer b)
+{
+	guint int_a = GPOINTER_TO_UINT(a);
+	guint int_b = GPOINTER_TO_UINT(b);
+
+	if (int_a < int_b)
+		return -1;
+
+	if (int_a > int_b)
+		return 1;
+
+	return 0;
+}
+
+static guint call_all_timeouts(void)
+{
+	GList *keys;
+	GList *iter;
+	guint count = 0;
+
+	DBG("%p", __timeouts);
+
+	if (!__timeouts || !g_hash_table_size(__timeouts))
+		return 0;
+
+	/*
+	 * Get the keys at the time we're about to call the callbacks. New
+	 * timeout functions may be added when callback is called and, thus
+	 * the hash table is altered. This way it is safe to call only those
+	 * that are now scheduled. Use sorted list as the keys increase at
+	 * each new timeout and the last would be normally returned as first.
+	 */
+	keys = g_list_sort(g_hash_table_get_keys(__timeouts), compare_uint);
+	DBG("%d keys", g_list_length(keys));
+
+	for (iter = keys; iter; iter = g_list_next(iter)) {
+		gpointer key;
+		gpointer value;
+
+		key = iter->data;
+
+		value = g_hash_table_lookup(__timeouts, key);
+		g_assert(value);
+
+		if (call_timeout(key, value))
+			count++;
+	}
+
+	g_list_free(keys);
+
+	DBG("called %u timeout functions", count);
+
+	return count;
+}
+
+static gint compare_timeout_function(gconstpointer a, gconstpointer b)
+{
+	const struct timeout_function *tf_a = a;
+	const struct timeout_function *tf_b = b;
+
+	if (tf_a->interval < tf_b->interval)
+		return -1;
+
+	if (tf_a->interval > tf_b->interval)
+		return 1;
+
+	return 0;
+}
+
+static guint call_all_timeouts_timed(void)
+{
+	GList *timeouts_sorted = NULL;
+	GList *keys;
+	GList *iter;
+	guint count = 0;
+
+	DBG("%p", __timeouts);
+
+	if (!__timeouts || !g_hash_table_size(__timeouts))
+		return 0;
+
+	/*
+	 * Get the keys at the time we're about to call the callbacks. New
+	 * timeout functions may be added when callback is called and, thus
+	 * the hash table is altered. This way it is safe to call only those
+	 * that are now scheduled.
+	 */
+	keys = g_hash_table_get_keys(__timeouts);
+	DBG("%d keys", g_list_length(keys));
+
+	for (iter = keys; iter; iter = g_list_next(iter)) {
+		gpointer key;
+		gpointer value;
+
+		key = iter->data;
+
+		value = g_hash_table_lookup(__timeouts, key);
+		g_assert(value);
+
+		/* Sort using the timeout */
+		timeouts_sorted = g_list_insert_sorted(timeouts_sorted, value,
+					compare_timeout_function);
+	}
+
+	for (iter = timeouts_sorted; iter; iter = g_list_next(iter))
+	{
+		if (call_timeout(0, iter->data))
+			count++;
+	}
+
+	g_list_free(keys);
+	g_list_free(timeouts_sorted);
+
+	DBG("called %u timeout functions", count);
+
+	return count;
+}
+
+static guint pending_timeouts(void)
+{
+	GHashTableIter iter;
+	gpointer key;
+	gpointer value;
+	guint count = 0;
+
+	if (!__timeouts)
+		return count;
+
+	g_hash_table_iter_init(&iter, __timeouts);
+	while (g_hash_table_iter_next(&iter, &key, &value)) {
+		struct timeout_function *tf;
+
+		tf = value;
+
+		if (tf->function && !tf->called && !tf->removed)
+			count++;
+	}
+
+	return count;
+}
+
+static struct connman_rtnl *r = NULL;
+
+int connman_rtnl_register(struct connman_rtnl *rtnl)
+{
+	g_assert(rtnl);
+	g_assert_null(r);
+	r = rtnl;
+	return 0;
+}
+
+void connman_rtnl_unregister(struct connman_rtnl *rtnl)
+{
+	g_assert(rtnl);
+	g_assert(rtnl == r);
+	r = NULL;
+}
+
+static bool rtprot_ra = false;
+
+void connman_rtnl_handle_rtprot_ra(bool value)
+{
+	rtprot_ra = value;
+	return;
+}
+
+const char *connman_setting_get_string(const char *key)
+{
+	return NULL;
+}
+
+static void test_reset(void) {
+	__task_run_count = 0;
+	__task_exit_value = 0;
+	if (__task)
+		free_task();
+
+	__def_service = NULL;
+
+	g_free(__last_set_contents_write);
+	__last_set_contents_write = NULL;
+
+	g_free(__last_set_contents);
+	__last_set_contents = NULL;
+
+	rtprot_ra = false;
+	resolv_id = 0;
+
+	__dad_callback = NULL;
+	__dad_user_data = NULL;
+
+	if (__resolv)
+		g_resolv_unref(__resolv);
+
+	if (__timeouts)
+		g_hash_table_destroy(__timeouts);
+	__timeouts = NULL;
+
+	__resolv_result_type = RESOLV_RESULT_GLOBAL;
+
+	__clat_dev_up = false;
+	__clat_dev_set = false;
+
+	__io_status = G_IO_STATUS_NORMAL;
+	g_free(__io_str);
+	__io_str = NULL;
+}
+
+#define TEST_PREFIX "/clat/"
+
+/* No default service bug state goes up to failure */
+static void clat_plugin_test1()
+{
+	struct connman_network network = { 0 };
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	/* There is no default service, nothing will get done */
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_FAILURE;
+					state++) {
+		service.state = state;
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	/* No timeouts have been called */
+	g_assert_null(__timeouts);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* Service goes to ready state and then becomes default */
+static void clat_plugin_test2()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * Mobile data goes first to ready, then comes default and comes online during
+ * pre conf.
+ */
+static void clat_plugin_test3()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* This has no effect during pre-conf */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_PRE);
+	g_assert_cmpint(__task_run_count, ==, 1);
+	g_assert_null(__last_set_contents_write);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * Mobile data goes first to ready, then comes default and comes online while
+ * running.
+ */
+static void clat_plugin_test4()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* This has no effect while running */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * Mobile data goes first to ready, then comes default and comes online
+ * during post-configure.
+ */
+static void clat_plugin_test5()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* This has no effect during post-configure */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* service goes ready -> not default -> online -> default */
+static void clat_plugin_test6()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* service goes ready when set already as default */
+static void clat_plugin_test7()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	/* Service is default before becoming ready */
+	__def_service = &service;
+	n->default_changed(&service);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state < CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	state = CONNMAN_SERVICE_STATE_READY;
+	service.state = state;
+	network.connected = true;
+	n->service_state_changed(&service, state);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+// service goes online -> failure when online
+static void clat_plugin_test_failure1()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Downgraded to ready, no change */
+	state = CONNMAN_SERVICE_STATE_READY;
+	service.state = state;
+	n->service_state_changed(&service, state);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Goes to failure -> stops throug post-conf */
+	DBG("RUNNING STOPS by state FAILURE");
+	state = CONNMAN_SERVICE_STATE_FAILURE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	/* State transition to post-configure */
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* pre-config shuts down with error */
+static void clat_plugin_test_failure2()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* Error in pre-configure */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(1);
+
+	/* Goes to cleanup */
+	g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_POST);
+	g_assert_cmpint(__task_run_count, ==, 2);
+	g_assert_null(__last_set_contents_write);
+	g_assert_true(check_task_running(TASK_SETUP_UNKNOWN, 0));
+
+	/* Goes to failure -> stops throug post-conf */
+	DBG("RUNNING STOPS by FAILURE");
+	call_task_exit(1);
+
+	g_assert_cmpint(__task_run_count, ==, 2);
+	g_assert_null(__last_set_contents_write);
+	g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* When running state process returns with 1 -> restart case */
+static void clat_plugin_test_failure3()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS with SEGFAULT");
+	call_task_exit(1);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Task is ended -> does restart*/
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	/* Back to pre-conf */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 1));
+
+	/* pre-conf ends and process starts */
+	DBG("PRE CONFIGURE stops (restart)");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 1));
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 1));
+
+	/* Task is ended -> does restart*/
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 1));
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* post conf segfaults */
+static void clat_plugin_test_failure4()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Task is ended with segfault */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(1);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+// resolv returns error (first ok, then ok, then error)
+static void clat_plugin_test_failure5()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+	int i;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* This has no effect during pre-conf */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_PRE);
+	g_assert_cmpint(__task_run_count, ==, 1);
+	g_assert_null(__last_set_contents_write);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	for (i = 0; i < 10 ; i++) {
+		/* No change */
+		call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+		g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+		/* Callbacks are added + remove resolv */
+		g_assert_cmpint(call_all_timeouts_timed(), ==, 3);
+
+		g_assert(__resolv);
+		g_assert(__dad_callback);
+		g_assert_true(call_dad_callback());
+
+		/* There should be always 2 callbacks, prefix query and DAD */
+		g_assert_cmpint(pending_timeouts(), ==, 2);
+	}
+
+	/* Error with resolv, process is stopped */
+	DBG("Resolv error NO_ANSWER");
+	call_resolv_result(G_RESOLV_RESULT_STATUS_NO_ANSWER);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* remove resolv exists */
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+// loop over all resolv returns
+static void clat_plugin_test_failure6()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_network network2 = {
+			.index = SERVICE_DEV_INDEX + 1,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_ipconfig ipv6config2 = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	struct connman_service service2 = {
+			.type = CONNMAN_SERVICE_TYPE_WIFI,
+			.state = CONNMAN_SERVICE_STATE_ONLINE,
+	};
+	enum connman_service_state state;
+	GResolvResultStatus status;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	service2.network = &network2;
+	service2.ipconfig_ipv6 = &ipv6config2;
+	assign_ipaddress(&ipv6config2);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state < CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	bool expect_resolv = false;
+	int timeout_count = 0;
+	int gresolv_timeouts = 0;
+
+	/*
+	 * Do each status individually by first going online, then default,
+	 * then report status, then leave as default and go ready as in normal
+	 * use.
+	 */
+	for (status = G_RESOLV_RESULT_STATUS_ERROR;
+			status <= G_RESOLV_RESULT_STATUS_NO_ANSWER;
+			status == G_RESOLV_RESULT_STATUS_NO_RESPONSE &&
+				gresolv_timeouts < 6 ?
+				status = G_RESOLV_RESULT_STATUS_NO_RESPONSE :
+				status++) {
+		DBG("test resolv result status %d", status);
+
+		if (status == G_RESOLV_RESULT_STATUS_NO_RESPONSE + 1)
+			g_assert_cmpint(gresolv_timeouts, ==, 6);
+
+		/* Nothing done as not being the default */
+		service.state = CONNMAN_SERVICE_STATE_ONLINE;
+		n->service_state_changed(&service, service.state);
+
+		g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+		g_assert_cmpint(__task_run_count, ==, 0);
+
+		if (expect_resolv)
+			g_assert(__resolv);
+		else
+			g_assert_null(__resolv);
+
+		g_assert_null(__dad_callback);
+		g_assert_cmpint(pending_timeouts(), ==, timeout_count);
+
+		/* Default service and is online */
+		__def_service = &service;
+		n->default_changed(&service);
+		g_assert_cmpint(__task_run_count, ==, 0);
+
+		/* Query is made -> call with error */
+		g_assert(__resolv);
+		g_assert_null(__last_set_contents_write);
+		call_resolv_result(status);
+
+		g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+		g_assert_cmpint(__task_run_count, ==, 0);
+
+		if (status == G_RESOLV_RESULT_STATUS_NO_RESPONSE) {
+			gresolv_timeouts++;
+
+			DBG("retry case (timeout) #%d", gresolv_timeouts);
+
+			/* This adds timeouts for retry remove resolv */
+			g_assert_cmpint(call_all_timeouts_timed(), ==, 2);
+			g_assert(__resolv);
+			g_assert_null(__dad_callback);
+			g_assert_cmpint(pending_timeouts(), ==, 1);
+
+			g_assert_false(check_task_running(TASK_SETUP_STOPPED,
+									0));
+			expect_resolv = true;
+			timeout_count = 1;
+		} else {
+			DBG("failure case");
+
+			/* This calls only the remove resolv timeout */
+			g_assert_cmpint(call_all_timeouts_timed(), ==, 1);
+			g_assert_null(__resolv);
+			g_assert_null(__dad_callback);
+			g_assert_cmpint(pending_timeouts(), ==, 0);
+
+			g_assert_false(check_task_running(TASK_SETUP_STOPPED,
+									0));
+
+			expect_resolv = false;
+			timeout_count = 0;
+
+			/* Default service changes and cellular goes to READY */
+			__def_service = &service2;
+			n->default_changed(&service2);
+		}
+
+		g_assert_cmpint(__task_run_count, ==, 0);
+
+		if (expect_resolv)
+			g_assert(__resolv); /* Retry in place */
+		else
+			g_assert_null(__resolv); /* Stopped */
+
+		g_assert_null(__dad_callback);
+		g_assert_cmpint(pending_timeouts(), ==, timeout_count);
+
+		/* To next timeout */
+		if (expect_resolv)
+			continue;
+
+		/* Going back to ready changes nothing as not being default */
+		service.state = CONNMAN_SERVICE_STATE_READY;
+		n->service_state_changed(&service, service.state);
+
+		g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+		g_assert_cmpint(__task_run_count, ==, 0);
+
+		g_assert_null(__resolv);
+		g_assert_null(__dad_callback);
+		g_assert_cmpint(pending_timeouts(), ==, timeout_count);
+	}
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+	connman_ipaddress_free(ipv6config2.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * Resolv returns timeout during initial query, then ok and then loops 7 times
+ * with timeout resulting in error
+ */
+static void clat_plugin_test_failure7()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+	int i;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with no response = timeout */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_NO_RESPONSE);
+
+	/* This transitions state to pre-configure */
+	g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+
+	/* GResolv removal and prefix query is restarted are added*/
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+	g_assert(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Second resolv is a success */
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* This has no effect during pre-conf */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_PRE);
+	g_assert_cmpint(__task_run_count, ==, 1);
+	g_assert_null(__last_set_contents_write);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added + remove resolv */
+	g_assert_cmpint(call_all_timeouts_timed(), ==, 3);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* 6 timeouts is ok */
+	for (i = 0; i < 6 ; i++) {
+		DBG("timeout %d", i);
+
+		/* Timeout that adds new query with shorter interval */
+		call_resolv_result(G_RESOLV_RESULT_STATUS_NO_RESPONSE);
+
+		/* Does not yet go off */ 
+		g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+		/* Callbacks are added + remove resolv */
+		g_assert_cmpint(call_all_timeouts_timed(), ==, 3);
+
+		g_assert(__resolv);
+		g_assert(__dad_callback);
+		g_assert_true(call_dad_callback());
+
+		/* There should be always 2 callbacks, prefix query and DAD */
+		g_assert_cmpint(pending_timeouts(), ==, 2);
+	}
+
+	/* 7th makes process to stop */
+	DBG("Resolv error NO_RESPONSE");
+	call_resolv_result(G_RESOLV_RESULT_STATUS_NO_ANSWER);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* remove resolv exists */
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * Resolv returns timeout during initial query, then ok and then loops 4 times
+ * with timeout resulting in error
+ */
+static void clat_plugin_test_failure8()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+	int i;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with no response = timeout */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_NO_RESPONSE);
+
+	/* This transitions state to pre-configure */
+	g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+
+	/* GResolv removal and prefix query is restarted are added*/
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+	g_assert(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Second resolv is a success */
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* This has no effect during pre-conf */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_PRE);
+	g_assert_cmpint(__task_run_count, ==, 1);
+	g_assert_null(__last_set_contents_write);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added + remove resolv */
+	g_assert_cmpint(call_all_timeouts_timed(), ==, 3);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* 4 timeouts */
+	for (i = 0; i < 4 ; i++) {
+		DBG("timeout %d", i);
+
+		/* Timeout that adds new query with shorter interval */
+		call_resolv_result(G_RESOLV_RESULT_STATUS_NO_RESPONSE);
+
+		/* Does not yet go off */ 
+		g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+		/* Callbacks are added + remove resolv */
+		g_assert_cmpint(call_all_timeouts_timed(), ==, 3);
+
+		g_assert(__resolv);
+		g_assert(__dad_callback);
+		g_assert_true(call_dad_callback());
+
+		/* There should be always 2 callbacks, prefix query and DAD */
+		g_assert_cmpint(pending_timeouts(), ==, 2);
+	}
+
+	/* And continue as normal */
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added + remove resolv */
+	g_assert_cmpint(call_all_timeouts_timed(), ==, 3);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* resolv returns different prefix_len -> restart case */
+static void clat_plugin_test_restart1()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure as a result of changed prefix */
+	DBG("RUNNING STOPS different prefix");
+	__resolv_result_type = RESOLV_RESULT_ONE_64;
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Resolv query is the one that remains */
+	g_assert(__resolv);
+	g_assert_cmpint(pending_timeouts(), ==, 1);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended -> does restart*/
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	/* Back to pre-conf */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 1));
+
+	/* resolv is re-added, call it */
+	g_assert(__resolv);
+	g_assert_cmpint(pending_timeouts(), ==, 1);
+	g_assert_null(__dad_callback);
+
+	/* pre-conf ends and process starts */
+	DBG("PRE CONFIGURE stops (restart)");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 1));
+
+	/* Callbacks are added, called and then re-added, the callback for
+	 * resolv also exists */
+	g_assert_cmpint(call_all_timeouts(), ==, 3);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* When called they re-add themselves */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 1));
+
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 1));
+
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* stdout/err have newline tailing */
+static const char *tayga_errors[] = {
+	"received error when reading from tun device: File descriptor in bad state\n",
+	"Unable to attach tun device clat, aborting: Device or resource busy\n",
+	"Unable to attach tun device clat, aborting: Invalid argument\n",
+	NULL
+};
+
+/* CLAT device is removed -> restart case */
+static void clat_plugin_test_restart2()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure as a result of changed prefix */
+	DBG("RUNNING STOPS clat device lost");
+	call_g_io_stderr(G_IO_IN, tayga_errors[0]);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* No resolv query is done, this restart is mainly tayga reload */
+	g_assert_null(__resolv);
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended -> does restart*/
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	/* Back to pre-conf */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 1));
+
+	/* resolv is not re-added */
+	g_assert_null(__resolv);
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__dad_callback);
+
+	/* pre-conf ends and process starts */
+	DBG("PRE CONFIGURE stops (restart)");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 1));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* When called they re-add themselves */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 1));
+
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 1));
+
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+// test different prefixes
+static void clat_plugin_test_prefix(gconstpointer data)
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	__resolv_result_type = GPOINTER_TO_INT(data);
+
+	DBG("resolv type %d", __resolv_result_type);
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* TODO check correct prefix from config */
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_set_prefix());
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* This has no effect while running */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * Each service type, except cellular goes through all states, in online state
+ * service pops as a default service.
+ */
+static void clat_plugin_test_service1()
+{
+	struct connman_network network = { 0 };
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_UNKNOWN,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+
+	DBG("");
+
+	service.network = &network;
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	__def_service = NULL;
+	n->default_changed(NULL);
+
+	for (service.type = CONNMAN_SERVICE_TYPE_UNKNOWN;
+				service.type < MAX_CONNMAN_SERVICE_TYPES;
+				service.type++)
+	{
+		/* Ignore cellular in this test */
+		if (service.type == CONNMAN_SERVICE_TYPE_CELLULAR)
+			continue;
+
+		/* There is no default service, nothing will get done */
+		for (service.state = CONNMAN_SERVICE_STATE_UNKNOWN;
+				service.state <= CONNMAN_SERVICE_STATE_FAILURE;
+				service.state++) {
+
+			/* Set default service to NULL after online change */
+			if (service.state ==
+					(CONNMAN_SERVICE_STATE_ONLINE + 1)) {
+				__def_service = NULL;
+				n->default_changed(NULL);
+			}
+
+			if (service.state == CONNMAN_SERVICE_STATE_READY)
+				network.connected = true;
+
+			n->service_state_changed(&service, service.state);
+
+			g_assert_null(__task);
+			g_assert_null(__resolv);
+
+			/* No timeouts have been called */
+			g_assert_null(__timeouts);
+			g_assert_null(__dad_callback);
+
+			/* Try default with online state sarvice */
+			if (service.state == CONNMAN_SERVICE_STATE_ONLINE) {
+				__def_service = &service;
+				n->default_changed(&service);
+
+				g_assert_null(__task);
+				g_assert_null(__resolv);
+
+				/* No timeouts have been called */
+				g_assert_null(__timeouts);
+				g_assert_null(__dad_callback);
+			}
+		}
+	}
+
+	__connman_builtin_clat.exit();
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * Mobile data goes first to ready, then comes default and comes online while
+ * running. Then another service becomes online and default -> mobile data
+ * goes to ready.
+ */
+static void clat_plugin_test_service2()
+{
+	struct connman_network network1 = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_network network2 = {
+			.index = SERVICE_DEV_INDEX + 1,
+	};
+	struct connman_ipconfig ipv6config1 = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_ipconfig ipv6config2 = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service1 = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	/* In service_sort() WIFI > CELLULAR */
+	struct connman_service service2 = {
+			.type = CONNMAN_SERVICE_TYPE_WIFI,
+			.state = CONNMAN_SERVICE_STATE_ONLINE,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service1.network = &network1;
+	service1.ipconfig_ipv6 = &ipv6config1;
+	assign_ipaddress(&ipv6config1);
+
+	service2.network = &network2;
+	service2.ipconfig_ipv6 = &ipv6config2;
+	assign_ipaddress(&ipv6config2);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service1.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network1.connected = true;
+
+		n->service_state_changed(&service1, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service1;
+	n->default_changed(&service1);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+	g_assert_cmpint(__task_run_count, ==, 1);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+	g_assert_cmpint(__task_run_count, ==, 2);
+
+	/* This has no effect while running */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service1.state = state;
+	n->service_state_changed(&service1, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+	g_assert_cmpint(__task_run_count, ==, 2);
+
+	/* Another service befomes default */
+	__def_service = &service2;
+	n->default_changed(&service2);
+
+	/* CLAT stops, state transition to post-configure */
+	DBG("RUNNING STOPS");
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+	g_assert_cmpint(__task_run_count, ==, 3);
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Cellular is downgraded to ready -> no change */
+	service1.state = CONNMAN_SERVICE_STATE_READY;
+	n->service_state_changed(&service1, state);
+
+	/* No timeouts are added */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(__task_run_count, ==, 3);
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config1.ipaddress);
+	connman_ipaddress_free(ipv6config2.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * Another service is default and then mobile data goes to ready, then comes
+ * default and comes online while running. Then another service becomes default
+ * -> mobile data goes to ready.
+ */
+static void clat_plugin_test_service3()
+{
+	struct connman_network network1 = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_network network2 = {
+			.index = SERVICE_DEV_INDEX + 1,
+	};
+	struct connman_ipconfig ipv6config1 = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_ipconfig ipv6config2 = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service1 = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	/* In service_sort() WIFI > CELLULAR */
+	struct connman_service service2 = {
+			.type = CONNMAN_SERVICE_TYPE_WIFI,
+			.state = CONNMAN_SERVICE_STATE_ONLINE,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service1.network = &network1;
+	service1.ipconfig_ipv6 = &ipv6config1;
+	assign_ipaddress(&ipv6config1);
+
+	service2.network = &network2;
+	service2.ipconfig_ipv6 = &ipv6config2;
+	assign_ipaddress(&ipv6config2);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service1.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network1.connected = true;
+
+		n->service_state_changed(&service1, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service2;
+	n->default_changed(&service2);
+
+	/* Nothing is done */
+	g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_cmpint(__task_run_count, ==, 0);
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* This has no effect while not being default yet */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service1.state = state;
+	n->service_state_changed(&service1, state);
+
+	/* Nothing is still done */
+	g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_cmpint(__task_run_count, ==, 0);
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Cellular service befomes default */
+	__def_service = &service1;
+	n->default_changed(&service1);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+	g_assert_cmpint(__task_run_count, ==, 1);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+	g_assert_cmpint(__task_run_count, ==, 2);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+	g_assert_cmpint(__task_run_count, ==, 2);
+
+	/* Another service befomes default again */
+	__def_service = &service2;
+	n->default_changed(&service2);
+
+	/* CLAT stops, state transition to post-configure */
+	DBG("RUNNING STOPS");
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+	g_assert_cmpint(__task_run_count, ==, 3);
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Cellular is downgraded to ready -> no change */
+	service1.state = CONNMAN_SERVICE_STATE_READY;
+	n->service_state_changed(&service1, state);
+
+	/* No timeouts are added */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(__task_run_count, ==, 3);
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config1.ipaddress);
+	connman_ipaddress_free(ipv6config2.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* Stop with null service as default */
+/*
+ * Mobile data goes first to ready, then comes default and comes online while
+ * running. Then another service becomes online and default -> mobile data
+ * goes to ready.
+ */
+static void clat_plugin_test_service4()
+{
+	struct connman_network network1 = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config1 = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service1 = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+
+	enum connman_service_state state;
+
+	DBG("");
+
+	service1.network = &network1;
+	service1.ipconfig_ipv6 = &ipv6config1;
+	assign_ipaddress(&ipv6config1);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service1.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network1.connected = true;
+
+		n->service_state_changed(&service1, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service1;
+	n->default_changed(&service1);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+	g_assert_cmpint(__task_run_count, ==, 1);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+	g_assert_cmpint(__task_run_count, ==, 2);
+
+	/* This has no effect while running */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service1.state = state;
+	n->service_state_changed(&service1, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+	g_assert_cmpint(__task_run_count, ==, 2);
+
+	/* NULL service befomes default and CLAT stops*/
+	__def_service = NULL;
+	n->default_changed(NULL);
+
+	/* CLAT stops, state transition to post-configure */
+	DBG("RUNNING STOPS");
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+	g_assert_cmpint(__task_run_count, ==, 3);
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Cellular is downgraded to ready -> no change */
+	service1.state = CONNMAN_SERVICE_STATE_READY;
+	n->service_state_changed(&service1, state);
+
+	/* No timeouts are added */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(__task_run_count, ==, 3);
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config1.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* Clat device error during pre-configure */
+static void clat_plugin_test_if_error1(gconstpointer data)
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+	unsigned int index = GPOINTER_TO_UINT(data);
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	/* Service is default before becoming ready */
+	__def_service = &service;
+	n->default_changed(&service);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state < CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	state = CONNMAN_SERVICE_STATE_READY;
+	service.state = state;
+	network.connected = true;
+	n->service_state_changed(&service, state);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+	g_assert_cmpint(__task_run_count, ==, 1);
+
+	/* Pre-configure reports error */
+	DBG("PRE CONFIGURE io error: \"%s\"", tayga_errors[index]);
+
+	g_assert_cmpint(__task_run_count, ==, 1);
+
+	/* Call with tayga error */
+	call_g_io_stderr(G_IO_IN, tayga_errors[index]);
+
+	g_assert_false(__clat_dev_set);
+	g_assert_false(__clat_dev_up);
+
+	/* Back to pre-conf without callbacks */
+	g_assert_true(check_task_running_added_rounds(TASK_SETUP_PRE, 1));
+	g_assert_cmpint(call_all_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running_added_rounds(TASK_SETUP_CONF, 1));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running_added_rounds(TASK_SETUP_POST, 1));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running_added_rounds(TASK_SETUP_STOPPED, 1));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+static void clat_plugin_test_if_error2(gconstpointer data)
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+	unsigned int index = GPOINTER_TO_UINT(data);
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended by device error */
+	DBG("POST CONFIGURE to error %s", tayga_errors[index]);
+
+	/*
+	 * Normally the device would be up and the --rmtun wasn't executed.
+	 * But the test check_task_running() with TASK_SETUP_POST sets the
+	 * __clat_dev_set to false then undo it for the sake of testing here.
+	 */
+	__clat_dev_set = true;
+
+	call_g_io_stderr(G_IO_IN, tayga_errors[index]);
+
+	g_assert_false(__clat_dev_set);
+	g_assert_false(__clat_dev_up);
+
+	/*
+	 * In post config case the removal is done prior / at the same time
+	 * the process dies.
+	 */
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* Different service reports something -> nothing done */
+static void clat_plugin_test_ipconfig1()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_network network_wifi = {
+			.index = SERVICE_DEV_INDEX + 1,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_ipconfig ipv4config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV4,
+			.method = CONNMAN_IPCONFIG_METHOD_DHCP,
+	};
+	struct connman_ipconfig ipv6config_wifi = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_ipconfig ipv4config_wifi = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV4,
+			.method = CONNMAN_IPCONFIG_METHOD_DHCP,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	struct connman_service service_wifi = {
+			.type = CONNMAN_SERVICE_TYPE_WIFI,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	struct connman_ipconfig *wifi_confs[] = {
+						NULL,
+						&ipv4config_wifi,
+						&ipv6config_wifi
+	};
+	enum connman_service_state state;
+	int i;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv4 = &ipv4config;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv4config);
+	assign_ipaddress(&ipv6config);
+
+	service_wifi.network = &network_wifi;
+	service_wifi.ipconfig_ipv4 = &ipv4config_wifi;
+	service_wifi.ipconfig_ipv6 = &ipv6config_wifi;
+	assign_ipaddress(&ipv4config_wifi);
+	assign_ipaddress(&ipv6config_wifi);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(call_all_timeouts_timed(), ==, 2);
+	g_assert_cmpint(__task_run_count, ==, 2);
+
+	/* Ignored: null ipconf, different service */
+	for (i = 0; i < 3; i++) {
+		DBG("wifi conf id %d", i);
+
+		n->ipconfig_changed(&service_wifi, wifi_confs[i]);
+
+		g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+		g_assert(__resolv);
+		g_assert(__dad_callback);
+
+		/* Simulate time */
+		g_assert_true(call_dad_callback());
+		g_assert_cmpint(call_all_timeouts_timed(), ==, 2);
+		g_assert_cmpint(__task_run_count, ==, 2);
+	}
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv4config.ipaddress);
+	connman_ipaddress_free(ipv6config.ipaddress);
+	connman_ipaddress_free(ipv4config_wifi.ipaddress);
+	connman_ipaddress_free(ipv6config_wifi.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* Cellular is not default or network is not connected */
+
+/* Running: IPv4 address is added and clat stops */
+/* Running: IPv6 address is removed and clat stops */
+static void clat_plugin_test_ipconfig_type(gconstpointer data)
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv4config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV4,
+			.method = CONNMAN_IPCONFIG_METHOD_DHCP,
+	};
+	struct connman_ipconfig ipv6config = { 
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+	int type = GPOINTER_TO_INT(data);
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(call_all_timeouts_timed(), ==, 2);
+	g_assert_cmpint(__task_run_count, ==, 2);
+
+	/* State transition to post-configure because of ipconfig change */
+	DBG("RUNNING STOPS, ipconfig changed");
+
+	/* Setup ipconfig */
+	if (type == AF_INET) {
+		/* IPv4 address is present -> stop */
+		service.ipconfig_ipv4 = &ipv4config;
+		assign_ipaddress(&ipv4config);
+		n->ipconfig_changed(&service, &ipv4config);
+	} else if (type == AF_INET6) {
+		/* IPv6 address is lost -> stop */
+		connman_ipaddress_clear(ipv6config.ipaddress);
+		n->ipconfig_changed(&service, &ipv6config);
+	}
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+
+	__connman_builtin_clat.exit();
+
+	if (type == AF_INET)
+		connman_ipaddress_free(ipv4config.ipaddress);
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+static gchar *option_debug = NULL;
+
+static bool parse_debug(const char *key, const char *value,
+					gpointer user_data, GError **error)
+{
+	if (value)
+		option_debug = g_strdup(value);
+	else
+		option_debug = g_strdup("*");
+
+	return true;
+}
+
+static GOptionEntry options[] = {
+	{ "debug", 'd', G_OPTION_FLAG_OPTIONAL_ARG,
+				G_OPTION_ARG_CALLBACK, parse_debug,
+				"Specify debug options to enable", "DEBUG" },
+	{ NULL },
+};
+
+int main (int argc, char *argv[])
+{
+	GOptionContext *context;
+	GError *error = NULL;
+
+	g_test_init(&argc, &argv, NULL);
+
+	context = g_option_context_new(NULL);
+	g_option_context_add_main_entries(context, options, NULL);
+
+	if (!g_option_context_parse(context, &argc, &argv, &error)) {
+		if (error) {
+			g_printerr("%s\n", error->message);
+			g_error_free(error);
+		} else
+			g_printerr("An unknown error occurred\n");
+		return 1;
+	}
+
+	g_option_context_free(context);
+
+	__connman_log_init(argv[0], option_debug, false, false,
+			"Unit Tests Connection Manager", VERSION);
+
+	g_test_add_func(TEST_PREFIX "test1", clat_plugin_test1);
+	g_test_add_func(TEST_PREFIX "test2", clat_plugin_test2);
+	g_test_add_func(TEST_PREFIX "test3", clat_plugin_test3);
+	g_test_add_func(TEST_PREFIX "test4", clat_plugin_test4);
+	g_test_add_func(TEST_PREFIX "test5", clat_plugin_test5);
+	g_test_add_func(TEST_PREFIX "test6", clat_plugin_test6);
+	g_test_add_func(TEST_PREFIX "test7", clat_plugin_test7);
+
+	g_test_add_func(TEST_PREFIX "test_failure1", clat_plugin_test_failure1);
+	g_test_add_func(TEST_PREFIX "test_failure2", clat_plugin_test_failure2);
+	g_test_add_func(TEST_PREFIX "test_failure3", clat_plugin_test_failure3);
+	g_test_add_func(TEST_PREFIX "test_failure4", clat_plugin_test_failure4);
+	g_test_add_func(TEST_PREFIX "test_failure5", clat_plugin_test_failure5);
+	g_test_add_func(TEST_PREFIX "test_failure6", clat_plugin_test_failure6);
+	g_test_add_func(TEST_PREFIX "test_failure7", clat_plugin_test_failure7);
+	g_test_add_func(TEST_PREFIX "test_failure8", clat_plugin_test_failure8);
+	
+	g_test_add_func(TEST_PREFIX "test_restart1", clat_plugin_test_restart1);
+	g_test_add_func(TEST_PREFIX "test_restart2", clat_plugin_test_restart2);
+
+	g_test_add_data_func(TEST_PREFIX "test_prefix1",
+					GINT_TO_POINTER(RESOLV_RESULT_ONE_64),
+					clat_plugin_test_prefix);
+	g_test_add_data_func(TEST_PREFIX "test_prefix2",
+					GINT_TO_POINTER(RESOLV_RESULT_ONE_96),
+					clat_plugin_test_prefix);
+	g_test_add_data_func(TEST_PREFIX "test_prefix3",
+					GINT_TO_POINTER(RESOLV_RESULT_SORT),
+					clat_plugin_test_prefix);
+
+	g_test_add_func(TEST_PREFIX "test_service1", clat_plugin_test_service1);
+	g_test_add_func(TEST_PREFIX "test_service2", clat_plugin_test_service2);
+	g_test_add_func(TEST_PREFIX "test_service3", clat_plugin_test_service3);
+	g_test_add_func(TEST_PREFIX "test_service4", clat_plugin_test_service4);
+
+	g_test_add_func(TEST_PREFIX "test_ipconfig1",
+						clat_plugin_test_ipconfig1);
+	g_test_add_data_func(TEST_PREFIX "test_ipconfig_ipv6_lost",
+						GINT_TO_POINTER(AF_INET6),
+						clat_plugin_test_ipconfig_type);
+	g_test_add_data_func(TEST_PREFIX "test_ipconfig_ipv4_added",
+						GINT_TO_POINTER(AF_INET),
+						clat_plugin_test_ipconfig_type);
+
+	g_test_add_data_func(TEST_PREFIX "test_if_error1.1",
+						GUINT_TO_POINTER(1),
+						clat_plugin_test_if_error1);
+	g_test_add_data_func(TEST_PREFIX "test_if_error1.2",
+						GUINT_TO_POINTER(2),
+						clat_plugin_test_if_error1);
+	g_test_add_data_func(TEST_PREFIX "test_if_error2.1",
+						GUINT_TO_POINTER(1),
+						clat_plugin_test_if_error2);
+	g_test_add_data_func(TEST_PREFIX "test_if_error2.2",
+						GUINT_TO_POINTER(2),
+						clat_plugin_test_if_error2);
+
+	return g_test_run();
+}

--- a/connman/unit/test-clat.c
+++ b/connman/unit/test-clat.c
@@ -170,42 +170,68 @@ int connman_inet_add_host_route(int index, const char *host,
 	return 0;
 }
 
+struct dual_nat {
+	char *ifname;
+	char *ipaddr_range;
+	unsigned char ipaddr_netmask;
+};
+
+static struct dual_nat *__dual_nat = NULL;
+
+struct route_entry {
+	int index;
+	char *host;
+	char *gateway;
+	char *netmask;
+	short metric;
+	unsigned long mtu;
+};
+
+static struct route_entry *__route_entry = NULL;
+
 int connman_inet_add_network_route_with_metric(int index, const char *host,
 					const char *gateway,
 					const char *netmask, short metric,
 					unsigned long mtu)
 {
+	DBG("index %d host %s gateway %s netmask %s metric %d mtu %ld", index,
+					host, gateway, netmask, metric, mtu);
+	
 	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
 	g_assert(host);
-	return 0;
-}
+	g_assert_null(__route_entry); /* CLAT should set only one IPv4 route */
 
-int connman_inet_add_network_route(int index, const char *host,
-						const char *gateway,
-						const char *netmask)
-{
-	return connman_inet_add_network_route_with_metric(index, host,
-							gateway, netmask, 0, 0);
-}
+	__route_entry = g_new0(struct route_entry, 1);
+	__route_entry->index = index;
+	__route_entry->host = g_strdup(host);
+	__route_entry->gateway = g_strdup(gateway);
+	__route_entry->netmask = g_strdup(netmask);
+	__route_entry->metric = metric;
+	__route_entry->mtu = mtu;
 
-int connman_inet_del_host_route(int index, const char *host)
-{
-	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
-	g_assert(host);
 	return 0;
 }
 
 int connman_inet_del_network_route_with_metric(int index, const char *host,
 					short metric)
 {
+	DBG("index %d host %s metric %d", index, host, metric);
+
 	g_assert_cmpint(index, ==, CLAT_DEV_INDEX);
 	g_assert(host);
-	return 0;
-}
 
-int connman_inet_del_network_route(int index, const char *host)
-{
-	return connman_inet_del_network_route_with_metric(index, host, 0);
+	g_assert(__route_entry);
+	g_assert_cmpint(__route_entry->index, ==, index);
+	g_assert_cmpstr(__route_entry->host, ==, host);
+	g_assert_cmpint(__route_entry->metric, ==, metric);
+
+	g_free(__route_entry->host);
+	g_free(__route_entry->gateway);
+	g_free(__route_entry->netmask);
+	g_free(__route_entry);
+	__route_entry = NULL;
+
+	return 0;
 }
 
 int connman_inet_clear_address(int index, struct connman_ipaddress *ipaddress)
@@ -468,6 +494,8 @@ static void call_task_exit(int exit_code)
 	}
 }
 
+static bool __vpn_mode = false;
+
 static gboolean task_running(enum task_setup setup, int add_run_count)
 {
 	if (!__task)
@@ -482,6 +510,8 @@ static gboolean task_running(enum task_setup setup, int add_run_count)
 		g_assert(__last_set_contents_write);
 		g_assert_true(g_str_has_suffix(__last_set_contents_write,
 								"tayga.conf"));
+		g_assert_null(__route_entry);
+		g_assert_null(__dual_nat);
 		g_free(__last_set_contents_write);
 		__last_set_contents_write = NULL;
 		break;
@@ -491,6 +521,10 @@ static gboolean task_running(enum task_setup setup, int add_run_count)
 		g_assert_true(__clat_dev_up);
 		g_assert_cmpint(__task_run_count, ==, 2 + add_run_count);
 		g_assert_null(__last_set_contents_write);
+		if (__vpn_mode)
+			g_assert_null(__route_entry);
+		else
+			g_assert(__route_entry);
 		break;
 	case TASK_SETUP_POST:
 		g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_POST);
@@ -498,6 +532,8 @@ static gboolean task_running(enum task_setup setup, int add_run_count)
 		g_assert_false(__clat_dev_up);
 		g_assert_cmpint(__task_run_count, ==, 3 + add_run_count);
 		g_assert_null(__last_set_contents_write);
+		g_assert_null(__route_entry);
+		g_assert_null(__dual_nat);
 		break;
 	case TASK_SETUP_STOPPED:
 		g_assert_cmpint(__task_run_count, ==, 3 + add_run_count);
@@ -551,7 +587,9 @@ struct connman_ipaddress *connman_ipconfig_get_ipaddress(
 {
 	DBG("ipconfig %p", ipconfig);
 
-	g_assert(ipconfig);
+	if (!ipconfig)
+		return NULL;
+
 	return ipconfig->ipaddress;
 }
 
@@ -591,12 +629,28 @@ int connman_nat_enable_double_nat_override(const char *ifname,
 	DBG("interface %s ipaddr_range %s ipaddr_netmask %u", ifname,
 						ipaddr_range, ipaddr_netmask);
 	g_assert(ifname);
+	g_assert_null(__dual_nat);
+
+	__dual_nat = g_new0(struct dual_nat, 1);
+	__dual_nat->ifname = g_strdup(ifname);
+	__dual_nat->ipaddr_range = g_strdup(ipaddr_range);
+	__dual_nat->ipaddr_netmask = ipaddr_netmask;
+
 	return 0;
 }
 
 void connman_nat_disable_double_nat_override(const char *ifname)
 {
+	DBG("interface %s", ifname);
+
 	g_assert(ifname);
+	g_assert(__dual_nat);
+	g_assert_cmpstr(__dual_nat->ifname, ==, ifname);
+
+	g_free(__dual_nat->ifname);
+	g_free(__dual_nat->ipaddr_range);
+	g_free(__dual_nat);
+	__dual_nat = NULL;
 }
 
 int connman_nat6_prepare(struct connman_ipconfig *ipconfig,
@@ -1434,6 +1488,8 @@ static void test_reset(void) {
 	__io_status = G_IO_STATUS_NORMAL;
 	g_free(__io_str);
 	__io_str = NULL;
+
+	__vpn_mode = false;
 }
 
 #define TEST_PREFIX "/clat/"
@@ -1500,6 +1556,7 @@ static void clat_plugin_test2()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -1606,6 +1663,7 @@ static void clat_plugin_test3()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -1723,6 +1781,7 @@ static void clat_plugin_test4()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -1837,6 +1896,7 @@ static void clat_plugin_test5()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -1949,6 +2009,7 @@ static void clat_plugin_test6()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -2052,6 +2113,7 @@ static void clat_plugin_test7()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -2159,6 +2221,7 @@ static void clat_plugin_test_failure1()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -2247,6 +2310,7 @@ static void clat_plugin_test_failure2()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -2327,6 +2391,7 @@ static void clat_plugin_test_failure3()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -2425,6 +2490,7 @@ static void clat_plugin_test_failure4()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -2505,6 +2571,7 @@ static void clat_plugin_test_failure5()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -2654,10 +2721,12 @@ static void clat_plugin_test_failure6()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	service2.network = &network2;
 	service2.ipconfig_ipv6 = &ipv6config2;
+	network2.ipv6_configured = true;
 	assign_ipaddress(&ipv6config2);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -2822,6 +2891,7 @@ static void clat_plugin_test_failure7()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -2971,6 +3041,7 @@ static void clat_plugin_test_failure8()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -3124,6 +3195,7 @@ static void clat_plugin_test_restart1()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -3282,6 +3354,7 @@ static void clat_plugin_test_restart2()
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -3432,6 +3505,7 @@ static void clat_plugin_test_prefix(gconstpointer data)
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -3642,10 +3716,12 @@ static void clat_plugin_test_service2()
 
 	service1.network = &network1;
 	service1.ipconfig_ipv6 = &ipv6config1;
+	network1.ipv6_configured = true;
 	assign_ipaddress(&ipv6config1);
 
 	service2.network = &network2;
 	service2.ipconfig_ipv6 = &ipv6config2;
+	network2.ipv6_configured = true;
 	assign_ipaddress(&ipv6config2);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -3793,10 +3869,12 @@ static void clat_plugin_test_service3()
 
 	service1.network = &network1;
 	service1.ipconfig_ipv6 = &ipv6config1;
+	network1.ipv6_configured = true;
 	assign_ipaddress(&ipv6config1);
 
 	service2.network = &network2;
 	service2.ipconfig_ipv6 = &ipv6config2;
+	network2.ipv6_configured = true;
 	assign_ipaddress(&ipv6config2);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -3951,6 +4029,7 @@ static void clat_plugin_test_service4()
 
 	service1.network = &network1;
 	service1.ipconfig_ipv6 = &ipv6config1;
+	network1.ipv6_configured = true;
 	assign_ipaddress(&ipv6config1);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -4082,6 +4161,7 @@ static void clat_plugin_test_if_error1(gconstpointer data)
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -4208,6 +4288,7 @@ static void clat_plugin_test_if_error2(gconstpointer data)
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -4321,10 +4402,6 @@ static void clat_plugin_test_ipconfig1()
 			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
 			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
 	};
-	struct connman_ipconfig ipv4config = {
-			.type = CONNMAN_IPCONFIG_TYPE_IPV4,
-			.method = CONNMAN_IPCONFIG_METHOD_DHCP,
-	};
 	struct connman_ipconfig ipv6config_wifi = {
 			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
 			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
@@ -4352,14 +4429,15 @@ static void clat_plugin_test_ipconfig1()
 	DBG("");
 
 	service.network = &network;
-	service.ipconfig_ipv4 = &ipv4config;
 	service.ipconfig_ipv6 = &ipv6config;
-	assign_ipaddress(&ipv4config);
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	service_wifi.network = &network_wifi;
 	service_wifi.ipconfig_ipv4 = &ipv4config_wifi;
 	service_wifi.ipconfig_ipv6 = &ipv6config_wifi;
+	network_wifi.ipv6_configured = true;
+	network_wifi.ipv4_configured = true;
 	assign_ipaddress(&ipv4config_wifi);
 	assign_ipaddress(&ipv6config_wifi);
 
@@ -4450,7 +4528,6 @@ static void clat_plugin_test_ipconfig1()
 
 	__connman_builtin_clat.exit();
 
-	connman_ipaddress_free(ipv4config.ipaddress);
 	connman_ipaddress_free(ipv6config.ipaddress);
 	connman_ipaddress_free(ipv4config_wifi.ipaddress);
 	connman_ipaddress_free(ipv6config_wifi.ipaddress);
@@ -4489,6 +4566,7 @@ static void clat_plugin_test_ipconfig_type(gconstpointer data)
 
 	service.network = &network;
 	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
 	assign_ipaddress(&ipv6config);
 
 	g_assert(__connman_builtin_clat.init() == 0);
@@ -4585,6 +4663,1029 @@ static void clat_plugin_test_ipconfig_type(gconstpointer data)
 	test_reset();
 }
 
+/*
+ * Mobile data goes first to ready, then comes default and comes online during
+ * pre conf. When running tethering is enabled.
+ */
+static void clat_plugin_test_tether1()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* This has no effect during pre-conf */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_PRE);
+	g_assert_cmpint(__task_run_count, ==, 1);
+	g_assert_null(__last_set_contents_write);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* No service changes but tethering is enabled -> dual nat is set */
+	n->tethering_changed(NULL, true);
+	g_assert(__dual_nat);
+
+	/* Tethering goes off, so does dual nat */
+	n->tethering_changed(NULL, false);
+	g_assert_null(__dual_nat);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * Tethering is enabled before CLAT is running.
+ */
+static void clat_plugin_test_tether2()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	n->tethering_changed(NULL, true);
+	g_assert_null(__dual_nat);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* No dual nat yet */
+	g_assert_null(__dual_nat);
+
+	/* This has no effect during pre-conf */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_PRE);
+	g_assert_cmpint(__task_run_count, ==, 1);
+	g_assert_null(__last_set_contents_write);
+
+	/* No dual nat yet */
+	g_assert_null(__dual_nat);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* Tethering was enabled -> dual nat is set */
+	g_assert(__dual_nat);
+
+	/* Tethering goes off, so does dual nat */
+	n->tethering_changed(NULL, false);
+	g_assert_null(__dual_nat);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/*
+ * CLAT stops before tethering is disabled -> dual nat is removed
+ */
+static void clat_plugin_test_tether3()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
+	assign_ipaddress(&ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	n->tethering_changed(NULL, true);
+	g_assert_null(__dual_nat);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* No dual nat yet */
+	g_assert_null(__dual_nat);
+
+	/* This has no effect during pre-conf */
+	state = CONNMAN_SERVICE_STATE_ONLINE;
+	service.state = state;
+	n->service_state_changed(&service, state);
+
+	g_assert_true(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_cmpint(get_task_setup(), ==, TASK_SETUP_PRE);
+	g_assert_cmpint(__task_run_count, ==, 1);
+	g_assert_null(__last_set_contents_write);
+
+	/* No dual nat yet */
+	g_assert_null(__dual_nat);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* Tethering was enabled -> dual nat is set */
+	g_assert(__dual_nat);
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+	g_assert_null(__dual_nat);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+	g_assert_null(__dual_nat);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+static void set_vpn_mode(bool enable)
+{
+	__vpn_mode = enable;
+}
+
+enum vpn_test_tether {
+	VPN_TEST_TETHER_OFF = 0,
+	VPN_TEST_TETHER_PRE,
+	VPN_TEST_TETHER_ON
+};
+
+/*
+ * CLAT running and IPv4 VPN goes on in CLAT running state  First CLAT
+ * goes online, then it goes ready and default service is changed to VPN. VPN
+ * does get to be set as default route and CLAT drops default route. This can
+ * be parametrized to have pre-VPN or during VPN tethering tested.
+ */
+void clat_plugin_test_vpn1(gconstpointer data)
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_ipconfig ipv4config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV4,
+			.method = CONNMAN_IPCONFIG_METHOD_DHCP,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	struct connman_service vpn_service = {
+			.type = CONNMAN_SERVICE_TYPE_VPN,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+	enum vpn_test_tether test_tether = GPOINTER_TO_UINT(data);
+
+	DBG("");
+
+	service.network = &network;
+	network.ipv6_configured = true;
+	service.ipconfig_ipv6 = &ipv6config;
+	assign_ipaddress(&ipv6config);
+
+	vpn_service.ipconfig_ipv4 = &ipv4config;
+	assign_ipaddress(&ipv4config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* Tethering is enabled before VPN is connected */
+	if (test_tether == VPN_TEST_TETHER_PRE) {
+		n->tethering_changed(NULL, true);
+		g_assert(__dual_nat);
+	}
+
+	/* VPN goes on by first dropping cellular to READY */
+	service.state = CONNMAN_SERVICE_STATE_READY;
+	n->service_state_changed(&service, CONNMAN_SERVICE_STATE_READY);
+
+	/* Nothing is done */
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+	g_assert(__resolv);
+	g_assert_null(__dad_callback); /* Timeout is not called yet */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* VPN goes to state transition */
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		vpn_service.state = state;
+		n->service_state_changed(&vpn_service, state);
+
+		/* Nothing is done */
+		g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+		g_assert(__resolv);
+		g_assert_null(__dad_callback); /* Timeout is not called yet */
+		g_assert_cmpint(pending_timeouts(), ==, 2);
+	}
+
+	/* Notify VPN IPv4 ipconf */
+	if (state == CONNMAN_SERVICE_STATE_READY) {
+		n->ipconfig_changed(&vpn_service,
+					vpn_service.ipconfig_ipv4);
+		
+		/* Nothing is done */
+		g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+		g_assert(__resolv);
+		g_assert_null(__dad_callback); /* Timeout is not called yet */
+		g_assert_cmpint(pending_timeouts(), ==, 2);
+	}
+
+	/* Next VPN is set as default and CLAT drops default route */
+	set_vpn_mode(true);
+	__def_service = &vpn_service;
+	n->default_changed(&vpn_service);
+
+	/* We keep on running without default route */
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+	g_assert(__resolv);
+	g_assert_null(__dad_callback); /* Timeout is not called yet */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* If tethering is enabled -> dual nat will not get set with IPv4 VPN */
+	if (test_tether == VPN_TEST_TETHER_ON)
+		n->tethering_changed(NULL, true);
+
+	/* Tethering was enabled before or after VPN -> dual nat is dropped */
+	if (test_tether != VPN_TEST_TETHER_OFF)
+		g_assert_null(__dual_nat);
+
+	/* CLAT becomes online - nothing is done yet */
+	service.state = CONNMAN_SERVICE_STATE_ONLINE;
+	n->service_state_changed(&service, CONNMAN_SERVICE_STATE_ONLINE);
+	
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+	g_assert(__resolv);
+	g_assert_null(__dad_callback); /* Timeout is not called yet */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* And then VPN disconnects and mobile data is the default */
+	vpn_service.state = CONNMAN_SERVICE_STATE_DISCONNECT;
+	n->service_state_changed(&vpn_service, vpn_service.state);
+
+	/* Nothing is done */
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+	g_assert(__resolv);
+	g_assert_null(__dad_callback); /* Timeout is not called yet */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* Until the default is changed.. */
+	set_vpn_mode(false);
+	__def_service = &service;
+	n->default_changed(&service);
+
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+	g_assert(__resolv);
+	g_assert_null(__dad_callback); /* Timeout is not called yet */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/*
+	 * Tethering is dropped after VPN disconnects. Nat restarts itself
+	 * when the default interface changes so it cannot nor should not be
+	 * tested here.
+	 */
+	if (test_tether != VPN_TEST_TETHER_OFF) {
+		n->tethering_changed(NULL, false);
+		g_assert_null(__dual_nat);
+	}
+
+	/* State transition to post-configure */
+	DBG("RUNNING STOPS");
+	call_task_exit(0);
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+	connman_ipaddress_free(ipv4config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* IPv6 VPN does cause CLAT to stop and start again when it disconnects */
+void clat_plugin_test_vpn2()
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_ipconfig vpn_ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_DHCP,
+	};
+	struct connman_service service = {
+			.type = CONNMAN_SERVICE_TYPE_CELLULAR,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	struct connman_service vpn_service = {
+			.type = CONNMAN_SERVICE_TYPE_VPN,
+			.state = CONNMAN_SERVICE_STATE_READY,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	network.ipv6_configured = true;
+	assign_ipaddress(&ipv6config);
+
+	vpn_service.ipconfig_ipv6 = &vpn_ipv6config;
+	assign_ipaddress(&vpn_ipv6config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 0));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* VPN goes on by first dropping cellular to READY */
+	service.state = CONNMAN_SERVICE_STATE_READY;
+	n->service_state_changed(&service, CONNMAN_SERVICE_STATE_READY);
+
+	/* Nothing is done */
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+	g_assert(__resolv);
+	g_assert_null(__dad_callback); /* Timeout is not called yet */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* VPN goes to state transition */
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		vpn_service.state = state;
+
+		n->service_state_changed(&vpn_service, state);
+
+		/* Nothing is done */
+		g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+		g_assert(__resolv);
+		g_assert_null(__dad_callback); /* Timeout is not called yet */
+		g_assert_cmpint(pending_timeouts(), ==, 2);
+	}
+
+	/* Notify VPN IPv6 ipconf */
+	if (state == CONNMAN_SERVICE_STATE_READY) {
+		n->ipconfig_changed(&vpn_service,
+					vpn_service.ipconfig_ipv6);
+		
+		/* Nothing is done */
+		g_assert_true(check_task_running(TASK_SETUP_CONF, 0));
+		g_assert(__resolv);
+		g_assert_null(__dad_callback); /* Timeout is not called yet */
+		g_assert_cmpint(pending_timeouts(), ==, 2);
+	}
+
+	/* Next IPv6 VPN is set as default and CLAT stops */
+	__def_service = &vpn_service;
+	n->default_changed(&vpn_service);
+
+	/* State transition to post-configure */
+	DBG("CLAT STOPS");
+	g_assert_true(check_task_running(TASK_SETUP_POST, 0));
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+
+	/* CLAT becomes online - nothing is done yet */
+	service.state = CONNMAN_SERVICE_STATE_ONLINE;
+	n->service_state_changed(&service, CONNMAN_SERVICE_STATE_ONLINE);
+
+	g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_null(__resolv);
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+
+	/* And then VPN disconnects and mobile data is the default */
+	vpn_service.state = CONNMAN_SERVICE_STATE_DISCONNECT;
+	n->service_state_changed(&vpn_service, vpn_service.state);
+
+	/* Nothing is done */
+	g_assert_false(check_task_running(TASK_SETUP_UNKNOWN, 0));
+	g_assert_null(__resolv);
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+
+	/* Until cellular is default again */
+	__def_service = &service;
+	n->default_changed(&service);
+
+	/* Query is made -> call with success */
+	g_assert(__resolv);
+	g_assert_null(__last_set_contents_write);
+	call_resolv_result(G_RESOLV_RESULT_STATUS_SUCCESS);
+
+	/* This transitions state to pre-configure */
+	g_assert_true(check_task_running(TASK_SETUP_PRE, 1));
+
+	/* GResolv removal is added, call it */
+	g_assert(__timeouts);
+	g_assert_cmpint(call_all_timeouts(), ==, 1);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	/* State transition to running */
+	DBG("PRE CONFIGURE stops");
+	call_task_exit(0);
+	g_assert_true(check_task_running(TASK_SETUP_CONF, 1));
+
+	/* Callbacks are added, called and then re-added */
+	g_assert_cmpint(call_all_timeouts(), ==, 2);
+
+	g_assert(__resolv);
+	g_assert(__dad_callback);
+	g_assert_true(call_dad_callback());
+
+	/* There should be always 2 callbacks, prefix query and DAD */
+	g_assert_cmpint(pending_timeouts(), ==, 2);
+
+	/* State transition to post-configure by disconnect */
+	DBG("RUNNING STOPS");
+	service.state = CONNMAN_SERVICE_STATE_DISCONNECT;
+	n->service_state_changed(&service, service.state);
+
+	/* Timeouts are removed */
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 1));
+
+	/* Setting default to NULL has no effect */
+	__def_service = NULL;
+	n->default_changed(NULL);
+
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	g_assert_true(check_task_running(TASK_SETUP_POST, 1));
+
+	/* Task is ended */
+	DBG("POST CONFIGURE stops");
+	call_task_exit(0);
+
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 1));
+	g_assert_cmpint(pending_timeouts(), ==, 0);
+	g_assert_null(__resolv);
+	g_assert_null(__dad_callback);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+	connman_ipaddress_free(vpn_ipv6config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* CLAT is not started when VPN is enabled over any service with IPv4 */
+void clat_plugin_test_vpn_type(gconstpointer data)
+{
+	struct connman_network network = {
+			.index = SERVICE_DEV_INDEX,
+	};
+	struct connman_ipconfig ipv6config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV6,
+			.method = CONNMAN_IPCONFIG_METHOD_AUTO,
+	};
+	struct connman_ipconfig ipv4config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV4,
+			.method = CONNMAN_IPCONFIG_METHOD_DHCP,
+	};
+	struct connman_ipconfig vpn_ipv4config = {
+			.type = CONNMAN_IPCONFIG_TYPE_IPV4,
+			.method = CONNMAN_IPCONFIG_METHOD_DHCP,
+	};
+	struct connman_service service = {
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	struct connman_service vpn_service = {
+			.type = CONNMAN_SERVICE_TYPE_VPN,
+			.state = CONNMAN_SERVICE_STATE_UNKNOWN,
+	};
+	enum connman_service_state state;
+
+	DBG("");
+
+	service.type = GPOINTER_TO_INT(data);
+	service.network = &network;
+	service.ipconfig_ipv6 = &ipv6config;
+	service.ipconfig_ipv4 = &ipv4config;
+	network.ipv6_configured = true;
+	network.ipv4_configured = true;
+	assign_ipaddress(&ipv6config);
+	assign_ipaddress(&ipv4config);
+
+	vpn_service.ipconfig_ipv4 = &vpn_ipv4config;
+	assign_ipaddress(&vpn_ipv4config);
+
+	g_assert(__connman_builtin_clat.init() == 0);
+
+	g_assert(n);
+	g_assert(r);
+	g_assert_true(rtprot_ra);
+
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_ONLINE;
+					state++) {
+		service.state = state;
+		if (state == CONNMAN_SERVICE_STATE_READY)
+			network.connected = true;
+
+		n->service_state_changed(&service, state);
+		g_assert_null(__task);
+		g_assert_null(__resolv);
+	}
+
+	__def_service = &service;
+	n->default_changed(&service);
+	g_assert_cmpint(__task_run_count, ==, 0);
+
+	/* Query is not made*/
+	g_assert_null(__resolv);
+	g_assert_null(__last_set_contents_write);
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_null(__timeouts);
+	g_assert_cmpint(pending_timeouts(), == , 0);
+
+	/* VPN goes on by first dropping cellular to READY */
+	service.state = CONNMAN_SERVICE_STATE_READY;
+	n->service_state_changed(&service, CONNMAN_SERVICE_STATE_READY);
+
+	/* Nothing is done */
+	g_assert_null(__resolv);
+	g_assert_null(__last_set_contents_write);
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_null(__timeouts);
+	g_assert_cmpint(pending_timeouts(), == , 0);
+
+	/* VPN goes to state transition */
+	for (state = CONNMAN_SERVICE_STATE_UNKNOWN;
+					state <= CONNMAN_SERVICE_STATE_READY;
+					state++) {
+		vpn_service.state = state;
+		n->service_state_changed(&vpn_service, state);
+
+		/* Nothing is done */
+		g_assert_null(__resolv);
+		g_assert_null(__last_set_contents_write);
+		g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+		g_assert_null(__timeouts);
+		g_assert_cmpint(pending_timeouts(), == , 0);
+	}
+
+	/* Notify VPN IPv4 ipconf */
+	if (state == CONNMAN_SERVICE_STATE_READY) {
+		n->ipconfig_changed(&vpn_service,
+					vpn_service.ipconfig_ipv4);
+		
+		/* Nothing is done */
+		g_assert_null(__resolv);
+		g_assert_null(__last_set_contents_write);
+		g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+		g_assert_null(__timeouts);
+		g_assert_cmpint(pending_timeouts(), == , 0);
+	}
+
+	/* Next VPN is set as default and CLAT drops default route */
+	set_vpn_mode(true);
+	__def_service = &vpn_service;
+	n->default_changed(&vpn_service);
+
+	g_assert_null(__resolv);
+	g_assert_null(__last_set_contents_write);
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_null(__timeouts);
+	g_assert_cmpint(pending_timeouts(), == , 0);
+
+	/* Mobile data becomes online */
+	service.state = CONNMAN_SERVICE_STATE_ONLINE;
+	n->service_state_changed(&service, CONNMAN_SERVICE_STATE_ONLINE);
+
+	g_assert_null(__resolv);
+	g_assert_null(__last_set_contents_write);
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_null(__timeouts);
+	g_assert_cmpint(pending_timeouts(), == , 0);
+
+	/* And then VPN disconnects and mobile data is the default */
+	vpn_service.state = CONNMAN_SERVICE_STATE_DISCONNECT;
+	n->service_state_changed(&vpn_service, vpn_service.state);
+
+	/* Nothing is done */
+	g_assert_null(__resolv);
+	g_assert_null(__last_set_contents_write);
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_null(__timeouts);
+	g_assert_cmpint(pending_timeouts(), == , 0);
+
+	/* Even when the default is changed.. */
+	set_vpn_mode(false);
+	__def_service = &service;
+	n->default_changed(&service);
+
+	g_assert_null(__resolv);
+	g_assert_null(__last_set_contents_write);
+	g_assert_false(check_task_running(TASK_SETUP_STOPPED, 0));
+	g_assert_null(__timeouts);
+	g_assert_cmpint(pending_timeouts(), == , 0);
+
+	__connman_builtin_clat.exit();
+
+	connman_ipaddress_free(ipv6config.ipaddress);
+	connman_ipaddress_free(ipv4config.ipaddress);
+	connman_ipaddress_free(vpn_ipv4config.ipaddress);
+
+	g_assert_false(rtprot_ra);
+	g_assert_null(n);
+	g_assert_null(r);
+	test_reset();
+}
+
+/* TODO : tethering tests */
+
 static gchar *option_debug = NULL;
 
 static bool parse_debug(const char *key, const char *value,
@@ -4663,6 +5764,37 @@ int main (int argc, char *argv[])
 	g_test_add_func(TEST_PREFIX "test_service2", clat_plugin_test_service2);
 	g_test_add_func(TEST_PREFIX "test_service3", clat_plugin_test_service3);
 	g_test_add_func(TEST_PREFIX "test_service4", clat_plugin_test_service4);
+
+	g_test_add_func(TEST_PREFIX "test_tether1", clat_plugin_test_tether1);
+	g_test_add_func(TEST_PREFIX "test_tether2", clat_plugin_test_tether2);
+	g_test_add_func(TEST_PREFIX "test_tether3", clat_plugin_test_tether3);
+
+	g_test_add_data_func(TEST_PREFIX "test_vpn1_no_tether",
+						GINT_TO_POINTER(
+							VPN_TEST_TETHER_OFF),
+						clat_plugin_test_vpn1);
+	g_test_add_data_func(TEST_PREFIX "test_vpn1_tether_pre_vpn",
+						GINT_TO_POINTER(
+							VPN_TEST_TETHER_PRE),
+						clat_plugin_test_vpn1);
+	g_test_add_data_func(TEST_PREFIX "test_vpn1_tether_during_vpn",
+						GINT_TO_POINTER(
+							VPN_TEST_TETHER_ON),
+						clat_plugin_test_vpn1);
+	g_test_add_func(TEST_PREFIX "test_vpn2", clat_plugin_test_vpn2);
+
+	g_test_add_data_func(TEST_PREFIX "test_vpn_type_cellular_v4_transport",
+						GINT_TO_POINTER(
+						CONNMAN_SERVICE_TYPE_CELLULAR),
+						clat_plugin_test_vpn_type);
+	g_test_add_data_func(TEST_PREFIX "test_vpn_type_wifi_transport",
+						GINT_TO_POINTER(
+						CONNMAN_SERVICE_TYPE_WIFI),
+						clat_plugin_test_vpn_type);
+	g_test_add_data_func(TEST_PREFIX "test_vpn_type_ethernet_transport",
+						GINT_TO_POINTER(
+						CONNMAN_SERVICE_TYPE_ETHERNET),
+						clat_plugin_test_vpn_type);
 
 	g_test_add_func(TEST_PREFIX "test_ipconfig1",
 						clat_plugin_test_ipconfig1);

--- a/rpm/connman.spec
+++ b/rpm/connman.spec
@@ -201,7 +201,8 @@ This package provides OpenFortiNet VPN plugin for connman.
     --enable-systemd \
     --with-tmpfilesdir=%{_prefix}/lib/tmpfiles.d \
     runstatedir=/run \
-    --enable-blacklist-monitor
+    --enable-blacklist-monitor \
+    --enable-clat
 
 %make_build
 

--- a/rpm/connman.spec
+++ b/rpm/connman.spec
@@ -20,6 +20,7 @@ Requires:   libglibutil >= 1.0.21
 Requires:   libdbusaccess >= 1.0.2
 Requires:   libgsupplicant >= 1.0.17
 Requires:   glib2 >= 2.62
+Requires:   tayga >= 0.9.2
 Requires(preun): systemd
 Requires(post): systemd
 Requires(postun): systemd


### PR DESCRIPTION
This is based on the PR https://github.com/sailfishos/connman/pull/39 and needs to be rebased whenever it is changed or merged.

With these changes a VPN mode to disable default route on the CLAT device and to ignore setting of double nat when tethering is made possible.