### PR TITLE
[ofono] Revert "Increase delayed connect wait to 5 seconds". JB#59714

### DIFF
--- a/connman/plugins/sailfish_ofono.c
+++ b/connman/plugins/sailfish_ofono.c
@@ -100,12 +100,8 @@ enum connctx_handler_id {
 #define ONLINE_CHECK_SEC  (2)
 /* Timeout for delayed set connected call, in milliseconds. */
 #define DELAYED_CONNECT_TIMEOUT_MS (100)
-/*
- *  Wait for approx 5s for address information from ofono. This defines the
- *  amount of cycles for delayed connect to run with the defined
- *  DELAYED_CONNECT_TIMEOUT_MS wait set for one cycle.
- */
-#define DELAYED_CONNECT_LIMIT (5000 / DELAYED_CONNECT_TIMEOUT_MS)
+/* Wait for approx 2s for address information from ofono. */
+#define DELAYED_CONNECT_LIMIT (2000 / DELAYED_CONNECT_TIMEOUT_MS)
 
 struct modem_data {
 	OfonoModem *modem;


### PR DESCRIPTION
This reverts commit 6b6e680c7df9a8c999a533c83ac89e9c5ccf933a.

The change did not solve any issue it was assumed to fix. It just made connection establishment with troublesome networks being much more slower, for the 5 second period set here.