### PR TITLE
[connman] Fix 64bit arch build warnings and deprecated func. Fixes JB#54603

### DIFF
--- a/connman/gdhcp/client.c
+++ b/connman/gdhcp/client.c
@@ -1114,7 +1114,7 @@ static int send_dhcpv6_msg(GDHCPClient *dhcp_client, int type, char *msg)
 
 	ret = dhcpv6_send_packet(dhcp_client->ifindex, packet, ptr - buf);
 
-	debug(dhcp_client, "sent %d pkt %p len %d", ret, packet, ptr - buf);
+	debug(dhcp_client, "sent %d pkt %p len %zd", ret, packet, ptr - buf);
 	return ret;
 }
 

--- a/connman/src/peer.c
+++ b/connman/src/peer.c
@@ -979,7 +979,7 @@ void connman_peer_add_service(struct connman_peer *peer,
 
 	service = g_malloc0(sizeof(struct _peer_service));
 	service->type = type;
-	service->data = g_memdup(data, data_length * sizeof(unsigned char));
+	service->data = g_memdup2(data, data_length * sizeof(unsigned char));
 	service->length = data_length;
 
 	peer->services = g_slist_prepend(peer->services, service);

--- a/connman/tools/stats-tool.c
+++ b/connman/tools/stats-tool.c
@@ -38,6 +38,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -226,7 +227,8 @@ static void stats_print_record(struct stats_record *rec)
 	char buffer[30];
 
 	strftime(buffer, 30, "%d-%m-%Y %T", localtime(&rec->ts));
-	printf("%p %lld %s %01d %llu %llu %llu %llu %llu %llu %llu %llu %d\n",
+	printf("%p %lld %s %01d %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %"
+		PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %d\n",
 		rec, (long long int)rec->ts, buffer,
 		rec->roaming,
 		rec->data.rx_packets,
@@ -316,21 +318,21 @@ static void stats_print_entries(struct stats_file *file)
 static void stats_print_rec_diff(struct stats_record *begin,
 					struct stats_record *end)
 {
-	printf("\trx_packets: %llu\n",
+	printf("\trx_packets:  %"PRIu64"\n",
 		end->data.rx_packets - begin->data.rx_packets);
-	printf("\ttx_packets: %llu\n",
+	printf("\ttx_packets:  %"PRIu64"\n",
 		end->data.tx_packets - begin->data.tx_packets);
-	printf("\trx_bytes:   %llu\n",
+	printf("\trx_bytes:    %"PRIu64"\n",
 		end->data.rx_bytes - begin->data.rx_bytes);
-	printf("\ttx_bytes:   %llu\n",
+	printf("\ttx_bytes:    %"PRIu64"\n",
 		end->data.tx_bytes - begin->data.tx_bytes);
-	printf("\trx_errors:  %llu\n",
+	printf("\trx_errors:   %"PRIu64"\n",
 		end->data.rx_errors - begin->data.rx_errors);
-	printf("\ttx_errors:  %llu\n",
+	printf("\ttx_errors:   %"PRIu64"\n",
 		end->data.tx_errors - begin->data.tx_errors);
-	printf("\trx_dropped: %llu\n",
+	printf("\trx_dropped:  %"PRIu64"\n",
 		end->data.rx_dropped - begin->data.rx_dropped);
-	printf("\ttx_dropped: %llu\n",
+	printf("\ttx_dropped:  %"PRIu64"\n",
 		end->data.tx_dropped - begin->data.tx_dropped);
 	printf("\ttime:       %d\n",
 		end->data.time - begin->data.time);

--- a/connman/unit/test-globalproxy.c
+++ b/connman/unit/test-globalproxy.c
@@ -289,7 +289,7 @@ DAPolicy* da_policy_new_full(const char* spec, const DA_ACTION* actions)
 // Needed to control permissions independent of reality
 void da_policy_unref(DAPolicy* policy)
 {
-	g_assert_cmphex((uint)policy, ==, POLICY_FAKE_POINTER);
+	g_assert_cmphex(GPOINTER_TO_UINT(policy), ==, POLICY_FAKE_POINTER);
 }
 
 // Replaces function from libdbusaccess/src/dbusaccess_policy.c
@@ -297,7 +297,7 @@ void da_policy_unref(DAPolicy* policy)
 DA_ACCESS da_policy_check(const DAPolicy* policy, const DACred* cred,
 			  guint action, const char* arg, DA_ACCESS def)
 {
-	g_assert_cmphex((uint)policy, ==, POLICY_FAKE_POINTER);
+	g_assert_cmphex(GPOINTER_TO_UINT(policy), ==, POLICY_FAKE_POINTER);
 
 	return test_access;
 }

--- a/connman/unit/test-storage.c
+++ b/connman/unit/test-storage.c
@@ -3239,7 +3239,7 @@ static void storage_test_user_change14()
 	/* connman_storage_update_finalize_cb modifies the contents of the *
 	 * registered callbacks list. To make the test idempotent, we copy *
 	 * the finalize_callback struct to a new address.                  */
-	callbacks = g_memdup(&finalize_callback,
+	callbacks = g_memdup2(&finalize_callback,
 				sizeof(struct connman_storage_callbacks));
 	test_path = setup_test_directory();
 	set_user_pw_dir_root(test_path);


### PR DESCRIPTION
Fix the warnings 64bit arch build gives. Also replace deprecated g_memdup() with the new g_memdup2().