### PR TITLE
[connman] Cleanup and fix index uses after CLAT VPN changes. Fixes JB#60897

### DIFF
--- a/connman/plugins/sailfish_ofono.c
+++ b/connman/plugins/sailfish_ofono.c
@@ -958,7 +958,7 @@ static void connctx_settings_changed(OfonoConnCtx *connctx, void *arg)
 
 	index = modem_configure(arg);
 
-	if (!md->network)
+	if (!md->network || index < 0)
 		return;
 
 	if (index != connman_network_get_index(md->network)) {

--- a/connman/src/connection.c
+++ b/connman/src/connection.c
@@ -423,9 +423,6 @@ static struct gateway_data *add_gateway(struct connman_service *service,
 static void set_default_gateway(struct gateway_data *data,
 				enum connman_ipconfig_type type)
 {
-	struct connman_ipconfig *ipconfig;
-	int index4;
-	int index6;
 	int status4 = 0;
 	int status6 = 0;
 	bool do_ipv4 = false;
@@ -471,25 +468,19 @@ static void set_default_gateway(struct gateway_data *data,
 		return;
 	}
 
-	ipconfig = __connman_service_get_ip4config(data->service);
-	index4 = __connman_ipconfig_get_index(ipconfig);
-
 	if (do_ipv4 && data->ipv4_gateway &&
 			g_strcmp0(data->ipv4_gateway->gateway,
 							"0.0.0.0") == 0) {
-		if (connman_inet_set_gateway_interface(index4) < 0)
+		if (connman_inet_set_gateway_interface(data->index4) < 0)
 			return;
 		data->ipv4_gateway->active = true;
 		goto done;
 	}
 
-	ipconfig = __connman_service_get_ip6config(data->service);
-	index6 = __connman_ipconfig_get_index(ipconfig);
-
 	if (do_ipv6 && data->ipv6_gateway &&
 			g_strcmp0(data->ipv6_gateway->gateway,
 							"::") == 0) {
-		if (connman_inet_set_ipv6_gateway_interface(index6) < 0)
+		if (connman_inet_set_ipv6_gateway_interface(data->index6) < 0)
 			return;
 		data->ipv6_gateway->active = true;
 		goto done;
@@ -497,11 +488,13 @@ static void set_default_gateway(struct gateway_data *data,
 
 	if (do_ipv6 && data->ipv6_gateway)
 		status6 = __connman_inet_add_default_to_table(RT_TABLE_MAIN,
-					index6, data->ipv6_gateway->gateway);
+					data->index6,
+					data->ipv6_gateway->gateway);
 
 	if (do_ipv4 && data->ipv4_gateway)
 		status4 = __connman_inet_add_default_to_table(RT_TABLE_MAIN,
-					index4, data->ipv4_gateway->gateway);
+					data->index4,
+					data->ipv4_gateway->gateway);
 
 	if (status4 < 0 || status6 < 0)
 		return;

--- a/connman/src/dnsproxy.c
+++ b/connman/src/dnsproxy.c
@@ -2975,8 +2975,10 @@ static void dnsproxy_default_changed(struct connman_service *service)
 static void dnsproxy_service_state_changed(struct connman_service *service,
 			enum connman_service_state state)
 {
+	struct connman_ipconfig *ipconfig;
 	GSList *list;
-	int index;
+	int index4;
+	int index6;
 
 	switch (state) {
 	case CONNMAN_SERVICE_STATE_DISCONNECT:
@@ -2991,7 +2993,12 @@ static void dnsproxy_service_state_changed(struct connman_service *service,
 		return;
 	}
 
-	index = __connman_service_get_index(service);
+	ipconfig = __connman_service_get_ip4config(service);
+	index4 = __connman_ipconfig_get_index(ipconfig);
+
+	ipconfig = __connman_service_get_ip6config(service);
+	index6 = __connman_ipconfig_get_index(ipconfig);
+
 	list = server_list;
 
 	while (list) {
@@ -3000,8 +3007,8 @@ static void dnsproxy_service_state_changed(struct connman_service *service,
 		/* Get next before the list is changed by destroy_server() */
 		list = list->next;
 
-		if (data->index == index) {
-			DBG("removing server data of index %d", index);
+		if (data->index == index4 || data->index == index6) {
+			DBG("removing server data of index %d", data->index);
 			destroy_server(data);
 		}
 	}


### PR DESCRIPTION
This contains mostly cleanups and minor fixes to interface index use after the CLAT VPN changes introduced big changes on the behavior by supporting separate interfaces per service.

- It is not necessary to get the indexes from the ipconfig in connection.c. Use the ones set in data directly to be more consistent.
- In ofono plugin avoid updating network index with invalid 
- In dnsproxy check both IPv{4,6} indexes when service state changes. 