### PR TITLE
[connman] Cleanup post-install script. Fixes JB#60966

### DIFF
--- a/rpm/connman.spec
+++ b/rpm/connman.spec
@@ -249,12 +249,6 @@ cp %{etc_resolv_conf} %{run_resolv_conf} || :
 fi
 rm -f %{etc_resolv_conf} || :
 ln -s %{run_resolv_conf} %{etc_resolv_conf} || :
-# Remove directories created by mistake in release 3.0.2
-for d in $(find /var/lib/connman -type d "(" -name "wifi_*" -o -name "ethernet_*_cable" ")") ; do
-if [ ! -f $d/settings ] ; then
-rm -fr $d
-fi
-done
 
 systemctl daemon-reload || :
 # Do not restart connman here or network breaks.


### PR DESCRIPTION
We have done multiple stop releases since this cleanup script was introduced. Thus, this can be safely removed.

See 3.0.2 release / sha1 cea1f1fd21b8b70dd70