### PR TITLE
Fix saving of  VPN provider in some cases.

### DIFF
--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -357,7 +357,7 @@ GKeyFile *__connman_storage_load_provider_config(const char *ident);
 
 int __connman_storage_save_service(GKeyFile *keyfile, const char *ident);
 GKeyFile *__connman_storage_load_provider(const char *identifier);
-void __connman_storage_save_provider(GKeyFile *keyfile, const char *identifier);
+int __connman_storage_save_provider(GKeyFile *keyfile, const char *identifier);
 bool __connman_storage_remove_provider(const char *identifier);
 char **__connman_storage_get_providers(void);
 bool __connman_storage_remove_service(const char *service_id);

--- a/connman/vpn/vpn-provider.c
+++ b/connman/vpn/vpn-provider.c
@@ -1317,6 +1317,7 @@ static int vpn_provider_save(struct vpn_provider *provider)
 {
 	GKeyFile *keyfile;
 	const char *value;
+	int err;
 
 	DBG("provider %p immutable %s", provider,
 					provider->immutable ? "yes" : "no");
@@ -1380,10 +1381,14 @@ static int vpn_provider_save(struct vpn_provider *provider)
 	if (provider->driver && provider->driver->save)
 		provider->driver->save(provider, keyfile);
 
-	__connman_storage_save_provider(keyfile, provider->identifier);
+	err = __connman_storage_save_provider(keyfile, provider->identifier);
+	if (err)
+		connman_error("Provider %s was not saved: %s",
+					provider->identifier, strerror(-err));
+
 	g_key_file_unref(keyfile);
 
-	return 0;
+	return err;
 }
 
 struct vpn_provider *__vpn_provider_lookup(const char *identifier)


### PR DESCRIPTION
On some devices, mostly older ones this was an issue that came out of nowhere that VPN providers were not saved when created or modified. No real idea what caused it because on new, such as Xperia 10 III this worked.

With the changes here at least X10 I got saving working again. Cleanup of code was also made in addition to increasing logging and error reporting.