### PR TITLE
[timezone] Fix handling of empty subpath in find_origin(). JB#61335

### DIFF
--- a/connman/src/timezone.c
+++ b/connman/src/timezone.c
@@ -196,7 +196,10 @@ static char *find_origin(void *src_map, struct stat *src_st,
 
 			if (compare_file(src_map, src_st, real_path, pathname)
 									== 0) {
-				str = g_strdup_printf("%s/%s",
+				if (!subpath)
+					str = g_strdup(d->d_name);
+				else
+					str = g_strdup_printf("%s/%s",
 							subpath, d->d_name);
 				closedir(dir);
 				return str;


### PR DESCRIPTION
Patch from upstream:

Add missing code for handling an empty subpath.