### PR TITLE
Enhance connman-vpnd debug use

### DIFF
--- a/connman/vpn/connman-vpn.service.in
+++ b/connman/vpn/connman-vpn.service.in
@@ -6,7 +6,9 @@ After=dbus.socket oneshot-root.service connman.service
 [Service]
 Type=dbus
 BusName=net.connman.vpn
-ExecStart=@sbindir@/connman-vpnd -n
+EnvironmentFile=-/etc/sysconfig/connman-vpn
+EnvironmentFile=-/var/lib/environment/connman-vpn/*.conf
+ExecStart=@sbindir@/connman-vpnd -n $SYSCONF_ARGS $CONNMAN_ARGS
 StandardOutput=null
 CapabilityBoundingSet=CAP_KILL CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_DAC_OVERRIDE CAP_SETGID CAP_SETUID CAP_CHOWN CAP_FOWNER
 ProtectSystem=full

--- a/connman/vpn/main.c
+++ b/connman/vpn/main.c
@@ -134,10 +134,19 @@ static bool option_version = false;
 static bool parse_debug(const char *key, const char *value,
 					gpointer user_data, GError **error)
 {
-	if (value)
-		option_debug = g_strdup(value);
-	else
+	if (value) {
+		if (option_debug) {
+			char *prev = option_debug;
+
+			option_debug = g_strconcat(prev, ",", value, NULL);
+			g_free(prev);
+		} else {
+			option_debug = g_strdup(value);
+		}
+	} else {
+		g_free(option_debug);
 		option_debug = g_strdup("*");
+	}
 
 	return true;
 }


### PR DESCRIPTION
Support multiple `-d` options at startup, implementation is the same as in connmand. Also read startup options similarly to connmand as the service starts.