### PR TITLE
 Start service after quota to avoid fs read-only issues

### DIFF
--- a/rpm/01-require-home-mount-to-be-present.conf
+++ b/rpm/01-require-home-mount-to-be-present.conf
@@ -4,7 +4,14 @@
 # PartOf ensures that connman is stopped before home is unmounted. This is
 # because if the configurations go missing when connman is running undefined
 # behavior can happen.
+# Running the service after quota for home has been run ensures that regardless
+# of what the quota service has (as quotacheck tries to remount the filesystem
+# read-only before starting the scan) resulting in situations where fs cannot be
+# written to, which was especially case with vpnd running on slower, older
+# devices. Setting this for connmand will make connman-vpnd work as well since
+# it depends on connman.service to start prior to starting VPN service.
 
 [Unit]
 RequiresMountsFor=/home
 PartOf=home.mount
+After=quota@home.service


### PR DESCRIPTION
Set the drop-in which requires home to be mounted to order connmand (and connman-vpnd, which depends on connmand) to run after the quota service for home has been run. Quota service is triggered by home.mount and may make the fs as read-only for the period of quota check. This is an insurance to ensure that there will be no filesystem read-only issues regardless of what the quota service does.