### PR TITLE
Use provider as parameter for vpn_died() in OpenFortiVPN

### DIFF
--- a/connman/vpn/plugins/openfortivpn.c
+++ b/connman/vpn/plugins/openfortivpn.c
@@ -146,7 +146,7 @@ static void ofv_died(struct connman_task *task, int exit_code, void *user_data)
 	struct ofv_private_data *data = user_data;
 
 	DBG("task %p, code %d, data %p", task, exit_code, user_data);
-	vpn_died(task, exit_code, user_data);
+	vpn_died(task, exit_code, data->provider);
 	free_private_data(data);
 }
 


### PR DESCRIPTION
This fixes crash when connecting to a server with invalid credentials. vpn.c:vpn_died() expects a pointer to the provider when called.