### PR TITLE
Calculate WiFi weak RSSI before lists are processed, remove network dbg

### DIFF
--- a/connman/src/network.c
+++ b/connman/src/network.c
@@ -2031,8 +2031,6 @@ uint16_t connman_network_get_wifi_channel(struct connman_network *network)
 int connman_network_set_string(struct connman_network *network,
 					const char *key, const char *value)
 {
-	DBG("network %p key %s value %s", network, key, value);
-
 	if (g_strcmp0(key, "Name") == 0)
 		return connman_network_set_name(network, value);
 


### PR DESCRIPTION
This will reduce at least debug noise but makes the calculation to be only once before it is needed.