### PR TITLE
Remove noisy warning, ignore interfaces added to/del from bridge

### DIFF
--- a/connman/src/rtnl.c
+++ b/connman/src/rtnl.c
@@ -956,7 +956,7 @@ static inline void print_attr(struct rtattr *attr, const char *name)
 		print("  attr %d (len %d)\n", attr->rta_type, len);
 }
 
-static void rtnl_link(struct nlmsghdr *hdr)
+static void rtnl_link(struct nlmsghdr *hdr, bool *has_master)
 {
 	struct ifinfomsg *msg;
 	struct rtattr *attr;
@@ -998,6 +998,7 @@ static void rtnl_link(struct nlmsghdr *hdr)
 			print_attr(attr, "priority");
 			break;
 		case IFLA_MASTER:
+			*has_master = true;
 			print_attr(attr, "master");
 			break;
 		case IFLA_WIRELESS:
@@ -1030,12 +1031,17 @@ static void rtnl_link(struct nlmsghdr *hdr)
 
 static void rtnl_newlink(struct nlmsghdr *hdr)
 {
+	bool has_master = false;
 	struct ifinfomsg *msg = (struct ifinfomsg *) NLMSG_DATA(hdr);
 
-	rtnl_link(hdr);
+	rtnl_link(hdr, &has_master);
 
 	if (hdr->nlmsg_type == IFLA_WIRELESS)
 		connman_warn_once("Obsolete WEXT WiFi driver detected");
+
+	/* ignore RTM_NEWLINK when adding interface to bridge */
+	if (has_master)
+		return;
 
 	process_newlink(msg->ifi_type, msg->ifi_index, msg->ifi_flags,
 				msg->ifi_change, msg, IFA_PAYLOAD(hdr));
@@ -1043,9 +1049,14 @@ static void rtnl_newlink(struct nlmsghdr *hdr)
 
 static void rtnl_dellink(struct nlmsghdr *hdr)
 {
+	bool has_master = false;
 	struct ifinfomsg *msg = (struct ifinfomsg *) NLMSG_DATA(hdr);
 
-	rtnl_link(hdr);
+	rtnl_link(hdr, &has_master);
+
+	/* ignore RTM_DELLINK when removing interface from bridge */
+	if (has_master)
+		return;
 
 	process_dellink(msg->ifi_type, msg->ifi_index, msg->ifi_flags,
 				msg->ifi_change, msg, IFA_PAYLOAD(hdr));

--- a/connman/src/rtnl.c
+++ b/connman/src/rtnl.c
@@ -203,7 +203,7 @@ static void read_uevent(struct interface_data *interface)
 			interface->service_type = CONNMAN_SERVICE_TYPE_ETHERNET;
 			interface->device_type = CONNMAN_DEVICE_TYPE_ETHERNET;
 		} else {
-			connman_warn("%s DEVTYPE=%s not supported, ignoring",
+			DBG("%s DEVTYPE=%s not supported, ignoring",
 					name, devtype);
 		}
 	} else {


### PR DESCRIPTION
Change the warning to DBG.

Apply upstream change for interface ignore in rtnl.