### PR TITLE
Use GResolv for DNS reresolve in WireGuard VPN plugin

### DIFF
--- a/connman/Makefile.am
+++ b/connman/Makefile.am
@@ -395,14 +395,15 @@ unit_test_sailfish_access_LDADD = @GLIB_LIBS@ @DBUSACCESS_LIBS@ -ldl
 unit_test_vpn_settings_CFLAGS = $(COVERAGE_OPT) $(AM_CFLAGS) \
 				-DDEFAULT_VPN_STATEDIR=\""$(vpn_statedir)"\" \
 				-DDEFAULT_USER_STORAGE=\""$(userstorage)"\"
-unit_test_vpn_settings_SOURCES = $(backtrace_sources) unit/test-vpn-settings.c \
+unit_test_vpn_settings_SOURCES = $(backtrace_sources) $(gweb_sources) \
+				unit/test-vpn-settings.c \
 				vpn/vpn-settings.c src/log.c vpn/vpn-util.c
-unit_test_vpn_settings_LDADD = @GLIB_LIBS@ -ldl
+unit_test_vpn_settings_LDADD = @GLIB_LIBS@ -ldl -lresolv
 
 unit_test_vpn_util_CFLAGS = $(COVERAGE_OPT) $(AM_CFLAGS)
-unit_test_vpn_util_SOURCES = unit/test-vpn-util.c src/log.c vpn/vpn-util.c \
-				$(backtrace_sources)
-unit_test_vpn_util_LDADD = @GLIB_LIBS@ -ldl
+unit_test_vpn_util_SOURCES = $(backtrace_sources) $(gweb_sources) \
+				unit/test-vpn-util.c src/log.c vpn/vpn-util.c
+unit_test_vpn_util_LDADD = @GLIB_LIBS@ -ldl -lresolv
 
 unit_test_service_CFLAGS = $(COVERAGE_OPT) $(AM_CFLAGS) \
 				-DDEFAULT_USER_STORAGE=\""$(userstorage)"\" \

--- a/connman/gweb/gresolv.c
+++ b/connman/gweb/gresolv.c
@@ -115,6 +115,7 @@ struct _GResolv {
 
 	GResolvDebugFunc debug_func;
 	gpointer debug_data;
+	int err;
 };
 
 #include "log.h"
@@ -1074,7 +1075,8 @@ guint g_resolv_lookup_hostname(GResolv *resolv, const char *hostname,
 	if (resolv->result_family != AF_INET6) {
 		if (add_query(lookup, hostname, ns_t_a)) {
 			g_free(lookup);
-			return -EIO;
+			resolv->err = -EIO;
+			return 0;
 		}
 	}
 
@@ -1087,7 +1089,8 @@ guint g_resolv_lookup_hostname(GResolv *resolv, const char *hostname,
 			}
 
 			g_free(lookup);
-			return -EIO;
+			resolv->err = -EIO;
+			return 0;
 		}
 	}
 
@@ -1132,4 +1135,12 @@ bool g_resolv_set_address_family(GResolv *resolv, int family)
 	resolv->result_family = family;
 
 	return true;
+}
+
+int g_resolv_get_error(GResolv *resolv)
+{
+	if (!resolv)
+		return 0;
+
+	return resolv->err;
 }

--- a/connman/gweb/gresolv.h
+++ b/connman/gweb/gresolv.h
@@ -75,6 +75,8 @@ bool g_resolv_cancel_lookup(GResolv *resolv, guint id);
 
 bool g_resolv_set_address_family(GResolv *resolv, int family);
 
+int g_resolv_get_error(GResolv *resolv);
+
 #ifdef __cplusplus
 }
 #endif

--- a/connman/vpn/vpn-util.c
+++ b/connman/vpn/vpn-util.c
@@ -221,3 +221,34 @@ out:
 	return err;
 }
 
+unsigned int vpn_util_resolve_hostname(GResolv *resolv,
+				const char *hostname, GResolvResultFunc func,
+				gpointer user_data)
+{
+	DBG("resolve %s", hostname);
+
+	return g_resolv_lookup_hostname(resolv, hostname, func, user_data);
+}
+
+bool vpn_util_cancel_resolve(GResolv *resolv, unsigned int id)
+{
+	DBG("");
+
+	return g_resolv_cancel_lookup(resolv, id);
+}
+
+GResolv *vpn_util_resolve_new(int index)
+{
+	return g_resolv_new(index);
+}
+
+void vpn_util_resolve_unref(GResolv *resolv)
+{
+	g_resolv_unref(resolv);
+}
+
+int vpn_util_get_resolve_error(GResolv *resolv)
+{
+	return g_resolv_get_error(resolv);
+}
+

--- a/connman/vpn/vpn.h
+++ b/connman/vpn/vpn.h
@@ -163,6 +163,16 @@ struct passwd *vpn_util_get_passwd(const char *username);
 struct group *vpn_util_get_group(const char *groupname);
 int vpn_util_create_path(const char *path, uid_t uid, gid_t grp, int mode);
 
+#include <gweb/gresolv.h>
+
+unsigned int vpn_util_resolve_hostname(GResolv *resolv,
+				const char *hostname, GResolvResultFunc func,
+				gpointer user_data);
+bool vpn_util_cancel_resolve(GResolv *resolv, unsigned int id);
+GResolv *vpn_util_resolve_new(int index);
+void vpn_util_resolve_unref(GResolv *resolv);
+int vpn_util_get_resolve_error(GResolv *resolv);
+
 #include "access.h"
 
 /* VPN Connection and Manager*/


### PR DESCRIPTION
In order to avoid blocking vpnd when network is not properly connected do the DNS reresolve with GResolve first, `getaddrinfo()` later.