### PR TITLE
[wireguard] Fix shutdown process and no-daemon VPN state machine. Fixes JB#62314

### DIFF
--- a/connman/vpn/plugins/vpn.c
+++ b/connman/vpn/plugins/vpn.c
@@ -75,6 +75,7 @@ static int stop_vpn(struct vpn_provider *provider)
 {
 	struct vpn_data *data = vpn_provider_get_data(provider);
 	struct vpn_driver_data *vpn_driver_data;
+	const struct vpn_driver *vpn_driver = NULL;
 	const char *name;
 	struct ifreq ifr;
 	int fd, err;
@@ -87,16 +88,19 @@ static int stop_vpn(struct vpn_provider *provider)
 		return -EINVAL;
 
 	vpn_driver_data = g_hash_table_lookup(driver_hash, name);
+	if (vpn_driver_data)
+		vpn_driver = vpn_driver_data->vpn_driver;
 
-	if (vpn_driver_data && vpn_driver_data->vpn_driver &&
-			vpn_driver_data->vpn_driver->flags & VPN_FLAG_NO_TUN) {
+	if (vpn_driver && vpn_driver->flags & VPN_FLAG_NO_TUN) {
 		/*
 		 * Disconnect only VPNs with daemon, otherwise in error return
 		 * there is a double free with vpn_died() or the failure state
 		 * is overridden by changes made by disconnect to state.
 		 */
-		if (!(vpn_driver_data->vpn_driver->flags & VPN_FLAG_NO_DAEMON))
-			vpn_driver_data->vpn_driver->disconnect(data->provider);
+		if (!(vpn_driver->flags & VPN_FLAG_NO_DAEMON) &&
+							vpn_driver->disconnect)
+			vpn_driver->disconnect(data->provider);
+
 		return 0;
 	}
 

--- a/connman/vpn/plugins/vpn.c
+++ b/connman/vpn/plugins/vpn.c
@@ -557,8 +557,6 @@ static gboolean update_provider_state(gpointer data)
 	vpn_data->watch = vpn_rtnl_add_newlink_watch(index,
 						vpn_newlink, provider);
 	connman_inet_ifup(index);
-	vpn_data->state = VPN_STATE_CONNECT;
-	vpn_provider_set_state(provider, VPN_PROVIDER_STATE_CONNECT);
 
 	return FALSE;
 }


### PR DESCRIPTION
The shutdown process needs vpn_died() to be called to complete the cycle. Do this as if simulating a VPN with daemon.

Tell that WireGuard uses no agent to complete the state machine and to not to change state in vpn.c. It was wrong, vpn-provider.c handles state transition when -EINPROGRESS is received to connect request.

Fix also one possible call made to nonexistent function.