### PR TITLE
Split routing and route setup changes for WireGuard

### DIFF
--- a/connman/src/inet.c
+++ b/connman/src/inet.c
@@ -632,6 +632,16 @@ int connman_inet_add_network_route_with_metric(int index, const char *host,
 	addr.sin_addr.s_addr = inet_addr(host);
 	memcpy(&rt.rt_dst, &addr, sizeof(rt.rt_dst));
 
+	/*
+	 * Don't add a routes for link-local or unspecified
+	 * destination address coupled with unspecified gateway.
+	 */
+	if ((!host || is_addr_ll(AF_INET, (struct sockaddr *)&addr) || __connman_inet_is_any_addr(host, AF_INET))
+			&& (!gateway || __connman_inet_is_any_addr(gateway, AF_INET))) {
+		close(sk);
+		return -EINVAL;
+	}
+
 	memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
 	if (gateway)
@@ -802,12 +812,26 @@ int connman_inet_add_ipv6_network_route_with_metric(int index, const char *host,
 					unsigned char prefix_len,
 					short metric)
 {
+	struct sockaddr_in6 addr;
 	struct in6_rtmsg rt;
 	int sk, err = 0;
 
 	DBG("index %d host %s gateway %s", index, host, gateway);
 
 	if (!host)
+		return -EINVAL;
+
+	if (inet_pton(AF_INET6, host, &addr.sin6_addr) != 1) {
+		err = -errno;
+		goto out;
+	}
+
+	/*
+	 * Don't add a route for link-local or unspecified
+	 * destination address coupled with unspecified gateway.
+	 */
+	if ((!host || is_addr_ll(AF_INET6, (struct sockaddr *)&addr) || __connman_inet_is_any_addr(host, AF_INET6))
+			&& (!gateway || __connman_inet_is_any_addr(gateway, AF_INET6)))
 		return -EINVAL;
 
 	memset(&rt, 0, sizeof(rt));

--- a/connman/vpn/vpn-provider.h
+++ b/connman/vpn/vpn-provider.h
@@ -130,6 +130,13 @@ int vpn_provider_set_nameservers(struct vpn_provider *provider,
 					const char *nameservers);
 int vpn_provider_append_route(struct vpn_provider *provider,
 					const char *key, const char *value);
+int vpn_provider_append_route_complete(struct vpn_provider *provider,
+				unsigned long idx, int family,
+				const char *address, const char *netmask,
+				const char *gateway);
+void vpn_provider_delete_all_routes(struct vpn_provider *provider);
+int vpn_provider_delete_route(struct vpn_provider *provider,
+							unsigned long index);
 
 const char *vpn_provider_get_driver_name(struct vpn_provider *provider);
 const char *vpn_provider_get_save_group(struct vpn_provider *provider);


### PR DESCRIPTION
With WireGuard split routing option is to be overridden as the AllowedIPs define the IP ranges that can be used according to the cryptokey routing table set on the server. Therefore, the split routing option is set only when there are no "any" routes defined.

This also contains changes to add routes to the IP networks defined with AllowedIPs. For now, the routes are added only based on the IP family of the current endpoint. The routes are removed and re-added if the endpoint resolves to another address, and in such case it is done without a delay. Normally, at startup, there is a 200ms delay.

Also took one upstream commit on preventing to add invalid routes to routing table. Might be useful in some cases, maybe even here.