### PR TITLE
Support dual IP addresses on VPNs

### DIFF
--- a/connman/Makefile.am
+++ b/connman/Makefile.am
@@ -216,7 +216,7 @@ vpn_connman_vpnd_SOURCES = $(builtin_vpn_sources) $(backtrace_sources) \
 			src/dbus.c src/storage.c src/ipaddress.c src/agent.c \
 			vpn/access.c vpn/vpn-agent.c vpn/vpn-agent.h \
 			src/inotify.c vpn/vpn-config.c src/fsid.c \
-			vpn/vpn-settings.c vpn/vpn-util.c
+			vpn/vpn-settings.c vpn/vpn-util.c src/shared/util.c
 
 vpn_connman_vpnd_LDADD = gdbus/libgdbus-internal.la $(builtin_vpn_libadd) \
 				@GLIB_LIBS@ @DBUS_LIBS@ @GNUTLS_LIBS@ @DBUSACCESS_LIBS@ \

--- a/connman/include/provider.h
+++ b/connman/include/provider.h
@@ -118,7 +118,7 @@ void connman_provider_set_autoconnect(struct connman_provider *provider,
 bool connman_provider_is_split_routing(struct connman_provider *provider);
 int connman_provider_set_split_routing(struct connman_provider *provider,
 							bool split_routing);
-int connman_provider_get_family(struct connman_provider *provider);
+bool connman_provider_get_family(struct connman_provider *provider, int family);
 void connman_provider_set_ipv6_data_leak_prevention(
 					struct connman_provider *provider,
 					bool enable);

--- a/connman/src/shared/util.c
+++ b/connman/src/shared/util.c
@@ -127,3 +127,43 @@ char *util_timeval_to_iso8601(struct timeval *time)
 
 	return g_strdup(buf);
 }
+
+void util_set_afs(bool *afs, int family)
+{
+	if (!afs)
+		return;
+
+	switch (family) {
+	case AF_INET:
+		afs[AF_INET_POS] = true;
+		break;
+	case AF_INET6:
+		afs[AF_INET6_POS] = true;
+		break;
+	default:
+		break;
+	}
+}
+
+bool util_get_afs(bool *afs, int family)
+{
+	if (!afs)
+		return false;
+
+	switch (family) {
+	case AF_INET:
+		return afs[AF_INET_POS];
+	case AF_INET6:
+		return afs[AF_INET6_POS];
+	default:
+		return false;
+	}
+}
+
+void util_reset_afs(bool *afs)
+{
+	if (!afs)
+		return;
+
+	afs[AF_INET_POS] = afs[AF_INET6_POS] = false;
+}

--- a/connman/src/shared/util.h
+++ b/connman/src/shared/util.h
@@ -24,6 +24,12 @@
 #include <sys/time.h>
 
 #include <glib.h>
+#include <stdbool.h>
+#include <inet.h>
+
+#define AF_INET_POS 0
+#define AF_INET6_POS 1
+#define AF_ARRAY_LENGTH 2
 
 typedef void (*util_debug_func_t)(const char *str, void *user_data);
 
@@ -53,3 +59,7 @@ static inline struct cb_data *cb_data_new(void *cb, void *user_data)
 
 void util_iso8601_to_timeval(char *str, struct timeval *time);
 char *util_timeval_to_iso8601(struct timeval *time);
+
+void util_set_afs(bool *afs, int family);
+bool util_get_afs(bool *afs, int family);
+void util_reset_afs(bool *afs);

--- a/connman/unit/test-service.c
+++ b/connman/unit/test-service.c
@@ -268,9 +268,9 @@ int connman_provider_get_index(struct connman_provider *provider)
 	return provider ? provider->index : -1;
 }
 
-int connman_provider_get_family(struct connman_provider *provider)
+bool connman_provider_get_family(struct connman_provider *provider, int family)
 {
-	return provider ? provider->family : PF_UNSPEC;
+	return provider && provider->family == family;
 }
 
 int __connman_provider_create_and_connect(DBusMessage *msg) { return 0; }

--- a/connman/vpn/vpn-provider.c
+++ b/connman/vpn/vpn-provider.c
@@ -56,6 +56,7 @@
 #include "vpn-provider.h"
 #include "vpn.h"
 #include "plugins/vpn.h"
+#include "../src/shared/util.h"
 
 static DBusConnection *connection;
 static GHashTable *provider_hash;
@@ -86,7 +87,7 @@ struct vpn_provider {
 	char *type;
 	char *host;
 	char *domain;
-	int family;
+	bool family[AF_ARRAY_LENGTH];
 	bool do_split_routing;
 	GHashTable *routes;
 	struct vpn_provider_driver *driver;
@@ -128,6 +129,31 @@ static guint connman_service_watch;
 static bool connman_online;
 static bool state_query_completed;
 static char *connman_dbus_name = NULL;
+
+
+static bool provider_get_family(struct vpn_provider *provider, int family)
+{
+	if (!provider)
+		return false;
+
+	return util_get_afs(provider->family, family);
+}
+
+static void provider_set_family(struct vpn_provider *provider, int family)
+{
+	if (!provider)
+		return;
+
+	util_set_afs(provider->family, family);
+}
+
+static void provider_reset_family(struct vpn_provider *provider)
+{
+	if (!provider)
+		return;
+
+	util_reset_afs(provider->family);
+}
 
 static void append_properties(DBusMessageIter *iter,
 				struct vpn_provider *provider);
@@ -2016,11 +2042,11 @@ static int provider_indicate_state(struct vpn_provider *provider,
 					VPN_CONNECTION_INTERFACE, "Index",
 					DBUS_TYPE_INT32, &provider->index);
 
-		if (provider->family == AF_INET)
+		if (provider_get_family(provider, AF_INET))
 			connman_dbus_property_changed_dict(provider->path,
 					VPN_CONNECTION_INTERFACE, "IPv4",
 					append_ipv4, provider);
-		else if (provider->family == AF_INET6)
+		if (provider_get_family(provider, AF_INET6))
 			connman_dbus_property_changed_dict(provider->path,
 					VPN_CONNECTION_INTERFACE, "IPv6",
 					append_ipv6, provider);
@@ -2118,10 +2144,10 @@ static void append_properties(DBusMessageIter *iter,
 	connman_dbus_dict_append_basic(&dict, "SplitRouting",
 					DBUS_TYPE_BOOLEAN, &split_routing);
 
-	if (provider->family == AF_INET)
+	if (provider_get_family(provider, AF_INET))
 		connman_dbus_dict_append_dict(&dict, "IPv4", append_ipv4,
 						provider);
-	else if (provider->family == AF_INET6)
+	if (provider_get_family(provider, AF_INET6))
 		connman_dbus_dict_append_dict(&dict, "IPv6", append_ipv6,
 						provider);
 
@@ -2179,18 +2205,16 @@ static void connection_added_signal(struct vpn_provider *provider)
 static int set_connected(struct vpn_provider *provider,
 					bool connected)
 {
-	struct vpn_ipconfig *ipconfig;
-
 	DBG("provider %p id %s connected %d", provider,
 					provider->identifier, connected);
 
 	if (connected) {
-		if (provider->family == AF_INET6)
-			ipconfig = provider->ipconfig_ipv6;
-		else
-			ipconfig = provider->ipconfig_ipv4;
-
-		__vpn_ipconfig_address_add(ipconfig, provider->family);
+		if (provider_get_family(provider, AF_INET))
+			__vpn_ipconfig_address_add(provider->ipconfig_ipv4,
+								AF_INET);
+		if (provider_get_family(provider, AF_INET6))
+			__vpn_ipconfig_address_add(provider->ipconfig_ipv6,
+								AF_INET6);
 
 		provider_indicate_state(provider,
 					VPN_PROVIDER_STATE_READY);
@@ -2200,6 +2224,7 @@ static int set_connected(struct vpn_provider *provider,
 
 		provider_indicate_state(provider,
 					VPN_PROVIDER_STATE_IDLE);
+		provider_reset_family(provider);
 	}
 
 	return 0;
@@ -3303,7 +3328,7 @@ int vpn_provider_set_ipaddress(struct vpn_provider *provider,
 	if (!ipconfig)
 		return -EINVAL;
 
-	provider->family = ipaddress->family;
+	provider_set_family(provider, ipaddress->family);
 
 	if (provider->state == VPN_PROVIDER_STATE_CONNECT ||
 			provider->state == VPN_PROVIDER_STATE_READY) {
@@ -3593,18 +3618,13 @@ unsigned int vpn_provider_get_connection_errors(
 
 void vpn_provider_change_address(struct vpn_provider *provider)
 {
-	switch (provider->family) {
-	case AF_INET:
+	if (provider_get_family(provider, AF_INET))
 		connman_inet_set_address(provider->index,
 			__vpn_ipconfig_get_address(provider->ipconfig_ipv4));
-		break;
-	case AF_INET6:
+
+	if (provider_get_family(provider, AF_INET6))
 		connman_inet_set_ipv6_address(provider->index,
 			__vpn_ipconfig_get_address(provider->ipconfig_ipv6));
-		break;
-	default:
-		break;
-	}
 }
 
 void vpn_provider_clear_address(struct vpn_provider *provider, int family)


### PR DESCRIPTION
This adds support for having both IPv4 and IPv6 on VPNs. Traditionally VPNs have been either or but WireGuard can utilize both.

Use a simple way of having the IP family types in an boolean array to avoid rewriting whole VPN implementation to match the other services. That work is to be done later.