### PR TITLE
Read only keys that exist from conf.d configs.

### DIFF
--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -144,7 +144,8 @@ void __connman_log_enable(struct connman_debug_desc *start,
 
 #include <connman/setting.h>
 
-void __connman_setting_read_config_values(GKeyFile *config, bool append);
+void __connman_setting_read_config_values(GKeyFile *config, bool mainconfig,
+								bool append);
 const char *__connman_setting_get_fallback_device_type(const char *interface);
 void __connman_setting_set_option(const char *key, const char *value);
 bool __connman_setting_is_supported_option(const char *key);

--- a/connman/src/main.c
+++ b/connman/src/main.c
@@ -106,7 +106,7 @@ static void check_config(GKeyFile *config, const char *file)
 	g_strfreev(keys);
 }
 
-static int config_init(const char *file, bool append)
+static int config_init(const char *file, bool mainconfig, bool append)
 {
 	GKeyFile *config;
 
@@ -114,7 +114,8 @@ static int config_init(const char *file, bool append)
 	if (config) {
 		DBG("parsing %s", file);
 		check_config(config, file);
-		__connman_setting_read_config_values(config, append);
+		__connman_setting_read_config_values(config, mainconfig,
+									append);
 		g_key_file_unref(config);
 	}
 
@@ -123,7 +124,7 @@ static int config_init(const char *file, bool append)
 
 static int config_read(const char *file)
 {
-	return config_init(file, false);
+	return config_init(file, false, false);
 }
 
 static GMainLoop *main_loop = NULL;
@@ -364,9 +365,9 @@ int main(int argc, char *argv[])
 
 	option = connman_setting_get_string(CONF_OPTION_CONFIG);
 	if (!option)
-		config_init(CONFIGMAINFILE, false);
+		config_init(CONFIGMAINFILE, true, false);
 	else
-		config_init(option, false);
+		config_init(option, true, false);
 
 	fs_err = util_read_config_files_from(CONFIGMAINDIR, CONFIGSUFFIX,
 				NULL, config_read);


### PR DESCRIPTION
The additional configs may have a small amount of keys, it is more optimal to read only what are set. Furthermore, this avoids from resetting values to default which have a default value, like a string list for blacklisted interfaces, when additional config is read by going through all the values.