### PR TITLE
Fix some Clang analyzer findings

### DIFF
--- a/connman/gdbus/watch.c
+++ b/connman/gdbus/watch.c
@@ -3,6 +3,7 @@
  *  D-Bus helper library
  *
  *  Copyright (C) 2004-2011  Marcel Holtmann <marcel@holtmann.org>
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -332,7 +333,6 @@ static void filter_data_call_and_free(struct filter_data *data)
 			cb->disc_func(data->connection, cb->user_data);
 		if (cb->destroy_func)
 			cb->destroy_func(cb->user_data);
-		g_free(cb);
 	}
 
 	filter_data_free(data);

--- a/connman/gweb/gresolv.c
+++ b/connman/gweb/gresolv.c
@@ -3,6 +3,7 @@
  *  Resolver library with GLib integration
  *
  *  Copyright (C) 2009-2013  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -159,6 +160,9 @@ static void _debug(GResolv *resolv, const char *file, const char *caller,
 
 static void destroy_query(struct resolv_query *query)
 {
+	if (!query)
+		return;
+
 	debug(query->resolv, "query %p timeout %d", query, query->timeout);
 
 	if (query->timeout > 0)

--- a/connman/gweb/gweb.c
+++ b/connman/gweb/gweb.c
@@ -3,6 +3,7 @@
  *  Web service library with GLib integration
  *
  *  Copyright (C) 2009-2013  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -604,8 +605,8 @@ static void start_request(struct web_session *session)
 {
 	GString *buf = session->send_buffer;
 	const char *version;
-	const guint8 *body;
-	gsize length;
+	const guint8 *body = NULL;
+	gsize length = 0;
 
 	debug(session->web, "request %s from %s",
 					session->request, session->host);
@@ -665,7 +666,7 @@ static void start_request(struct web_session *session)
 			g_string_append_printf(buf, "%zx\r\n", length);
 			g_string_append_len(buf, (char *) body, length);
 			g_string_append(buf, "\r\n");
-		} else if (session->fd == -1)
+		} else if (session->fd == -1 && body)
 			g_string_append_len(buf, (char *) body, length);
 	}
 }

--- a/connman/plugins/vpn.c
+++ b/connman/plugins/vpn.c
@@ -4,6 +4,7 @@
  *
  *  Copyright (C) 2012-2013  Intel Corporation. All rights reserved.
  *  Copyright (C) 2019-2021  Jolla Ltd.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -409,7 +410,7 @@ static int extract_ip(DBusMessageIter *array, int family,
 {
 	DBusMessageIter dict;
 	char *address = NULL, *gateway = NULL, *netmask = NULL, *peer = NULL;
-	unsigned char prefix_len;
+	unsigned char prefix_len = 128;
 
 	if (dbus_message_iter_get_arg_type(array) != DBUS_TYPE_ARRAY)
 		return -EINVAL;

--- a/connman/plugins/vpn.c
+++ b/connman/plugins/vpn.c
@@ -492,8 +492,10 @@ static int extract_nameservers(DBusMessageIter *array,
 		DBG("[%d] %s", i, nameserver);
 
 		nameservers[i] = g_strdup(nameserver);
-		if (!nameservers[i])
+		if (!nameservers[i]) {
+			g_free(nameservers);
 			return -ENOMEM;
+		}
 
 		nameservers[++i] = NULL;
 

--- a/connman/src/dhcpv6.c
+++ b/connman/src/dhcpv6.c
@@ -3,6 +3,7 @@
  *  Connection Manager
  *
  *  Copyright (C) 2012-2013  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -2075,6 +2076,7 @@ static GDHCPClient *create_pd_client(struct connman_dhcpv6 *dhcp, int *err)
 
 	g_dhcpv6_client_create_iaid(dhcp_client, index, (unsigned char *)&iaid);
 	g_dhcpv6_client_set_iaid(dhcp_client, iaid);
+	*err = 0;
 
 	return dhcp_client;
 }

--- a/connman/src/firewall-iptables.c
+++ b/connman/src/firewall-iptables.c
@@ -5,6 +5,7 @@
  *  Copyright (C) 2013,2015  BMW Car IT GmbH.
  *  Copyright (C) 2018,2019  Jolla Ltd.
  *  Copyright (C) 2019  Open Mobile Platform LLC.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -2363,7 +2364,7 @@ static int restore_policies(int family, char **policies, char **set_policies)
 
 	DBG("");
 
-	if (!policies && !set_policies)
+	if (!policies || !set_policies)
 		return -EINVAL;
 
 	for (i = NF_IP_LOCAL_IN; i < NF_IP_NUMHOOKS - 1; i++) {

--- a/connman/src/ipconfig.c
+++ b/connman/src/ipconfig.c
@@ -3,6 +3,7 @@
  *  Connection Manager
  *
  *  Copyright (C) 2007-2013  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -285,8 +286,10 @@ static int read_conf_value(const char *prefix, const char *ifname,
 	int err;
 
 	path = g_build_filename(prefix, ifname ? ifname : "all", suffix, NULL);
-	if (!path)
+	if (!path) {
+		*value = -ENOMEM;
 		return -ENOMEM;
+	}
 
 	errno = 0;
 	f = fopen(path, "r");
@@ -297,7 +300,7 @@ static int read_conf_value(const char *prefix, const char *ifname,
 
 		err = fscanf(f, "%d", value);
 		if (err <= 0 && errno)
-			err = -errno;
+			*value = err = -errno;
 
 		fclose(f);
 	}
@@ -362,7 +365,7 @@ static int write_ipv6_conf_value(const char *ifname, const char *suffix,
 
 static bool get_ipv6_state(gchar *ifname)
 {
-	int disabled;
+	int disabled = 0;
 	bool enabled = false;
 
 	if (read_ipv6_conf_value(ifname, "disable_ipv6", &disabled) > 0)
@@ -382,7 +385,7 @@ static int set_ipv6_state(gchar *ifname, bool enable)
 
 static int get_ipv6_privacy(gchar *ifname)
 {
-	int value;
+	int value = 0;
 
 	if (!ifname)
 		return 0;
@@ -418,7 +421,7 @@ static int set_ipv6_autoconf(gchar *ifname, bool enable)
 
 static int get_rp_filter(void)
 {
-	int value;
+	int value = 0;
 
 	if (read_ipv4_conf_value(NULL, "rp_filter", &value) < 0)
 		value = -EINVAL;
@@ -463,7 +466,7 @@ static int set_ipv6_accept_ra(gchar *ifname, int value)
 
 static int get_ipv6_accept_ra(gchar *ifname)
 {
-	int value;
+	int value = 0;
 
 	if (read_ipv6_conf_value(ifname, "accept_ra", &value) < 0)
 		value = -EINVAL;
@@ -482,7 +485,7 @@ static int set_ipv6_ndproxy(gchar *ifname, bool enable)
 
 static int get_ipv6_ndproxy(gchar *ifname)
 {
-	int value;
+	int value = 0;
 
 	if (read_ipv6_conf_value(ifname, "proxy_ndp", &value) < 0)
 		value = -EINVAL;

--- a/connman/src/storage.c
+++ b/connman/src/storage.c
@@ -5,6 +5,7 @@
  *  Copyright (C) 2007-2013  Intel Corporation. All rights reserved.
  *  Copyright (C) 2019-2020  Jolla Ltd. All rights reserved.
  *  Copyright (C) 2020  Open Mobile Platform LLC.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -402,8 +403,11 @@ static void storage_subdir_append(const char *name)
 	subdir->name = g_strdup(name);
 
 	storagedir = storagedir_for(subdir->name);
-	if (!storagedir)
+	if (!storagedir) {
+		g_free(subdir->name);
+		g_free(subdir);
 		return;
+	}
 
 	str = g_build_filename(storagedir, subdir->name, SETTINGS, NULL);
 	DBG("path %s", str);

--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -5,6 +5,7 @@
  *  Copyright (C) 2007-2013  Intel Corporation. All rights reserved.
  *  Copyright (C) 2014-2020  Jolla Ltd. All rights reserved.
  *  Copyright (C) 2020  Open Mobile Platform LLC.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -1012,7 +1013,10 @@ static gboolean enable_delayed(gpointer user_data)
 
 	DBG("");
 
-	if (!technology || technology->enabled)
+	if (!technology)
+		return G_SOURCE_REMOVE;
+
+	if (technology->enabled)
 		goto out;
 
 	err = technology_enable(technology);

--- a/connman/vpn/plugins/openvpn.c
+++ b/connman/vpn/plugins/openvpn.c
@@ -5,6 +5,7 @@
  *  Copyright (C) 2010-2014  BMW Car IT GmbH.
  *  Copyright (C) 2016-2019  Jolla Ltd.
  *  Copyright (C) 2019  Open Mobile Platform LLC.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -123,7 +124,10 @@ struct ov_private_data {
 
 static void ov_connect_done(struct ov_private_data *data, int err)
 {
-	if (data && data->cb) {
+	if (!data)
+		return;
+
+	if (data->cb) {
 		vpn_provider_connect_cb_t cb = data->cb;
 		void *user_data = data->user_data;
 

--- a/connman/vpn/plugins/vpn.c
+++ b/connman/vpn/plugins/vpn.c
@@ -532,7 +532,6 @@ static void vpn_task_setup(gpointer user_data)
 	DBG("vpn_task_setup uid:%d gid:%d supplementary group list size:%zu",
 					uid, gid, gid_list_size);
 
-
 	/* Change group if proper group name was set, requires CAP_SETGID.*/
 	if (gid > 0 && setgid(gid))
 		connman_error("error setting gid %d %s", gid, strerror(errno));
@@ -544,6 +543,8 @@ static void vpn_task_setup(gpointer user_data)
 	/* Change user for the task if set, requires CAP_SETUID */
 	if (uid > 0 && setuid(uid))
 		connman_error("error setting uid %d %s", uid, strerror(errno));
+
+	g_free(gid_list);
 }
 
 

--- a/connman/vpn/plugins/vpn.c
+++ b/connman/vpn/plugins/vpn.c
@@ -3,6 +3,7 @@
  *  ConnMan VPN daemon
  *
  *  Copyright (C) 2007-2013  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2025  Jolla Mobile Ltd
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -176,7 +177,8 @@ void vpn_died(struct connman_task *task, int exit_code, void *user_data)
 
 vpn_exit:
 	if (state != VPN_STATE_READY && state != VPN_STATE_DISCONNECT) {
-		if (vpn_data && vpn_data->vpn_driver->error_code)
+		if (vpn_data && vpn_data->vpn_driver &&
+					vpn_data->vpn_driver->error_code)
 			ret = vpn_data->vpn_driver->error_code(provider,
 					exit_code);
 		else


### PR DESCRIPTION
These fixes are for some Clang analyzer findings. There are still more, some false positives and relying on memory allocation failing or does not understand the unref-approach used in many places, but these are most obvious ones for now.