### PR TITLE
Make WireGuard to work better with network changes

### DIFF
--- a/connman/src/inet.c
+++ b/connman/src/inet.c
@@ -632,16 +632,6 @@ int connman_inet_add_network_route_with_metric(int index, const char *host,
 	addr.sin_addr.s_addr = inet_addr(host);
 	memcpy(&rt.rt_dst, &addr, sizeof(rt.rt_dst));
 
-	/*
-	 * Don't add a routes for link-local or unspecified
-	 * destination address coupled with unspecified gateway.
-	 */
-	if ((!host || is_addr_ll(AF_INET, (struct sockaddr *)&addr) || __connman_inet_is_any_addr(host, AF_INET))
-			&& (!gateway || __connman_inet_is_any_addr(gateway, AF_INET))) {
-		close(sk);
-		return -EINVAL;
-	}
-
 	memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
 	if (gateway)
@@ -812,26 +802,12 @@ int connman_inet_add_ipv6_network_route_with_metric(int index, const char *host,
 					unsigned char prefix_len,
 					short metric)
 {
-	struct sockaddr_in6 addr;
 	struct in6_rtmsg rt;
 	int sk, err = 0;
 
 	DBG("index %d host %s gateway %s", index, host, gateway);
 
 	if (!host)
-		return -EINVAL;
-
-	if (inet_pton(AF_INET6, host, &addr.sin6_addr) != 1) {
-		err = -errno;
-		goto out;
-	}
-
-	/*
-	 * Don't add a route for link-local or unspecified
-	 * destination address coupled with unspecified gateway.
-	 */
-	if ((!host || is_addr_ll(AF_INET6, (struct sockaddr *)&addr) || __connman_inet_is_any_addr(host, AF_INET6))
-			&& (!gateway || __connman_inet_is_any_addr(gateway, AF_INET6)))
 		return -EINVAL;
 
 	memset(&rt, 0, sizeof(rt));

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -8866,15 +8866,18 @@ static int service_connect(struct connman_service *service)
 	else
 		return -EOPNOTSUPP;
 
-	if (err < 0) {
-		if (err != -EINPROGRESS) {
-			__connman_service_ipconfig_indicate_state(service,
+	switch (err) {
+	case 0:
+	case -EALREADY:
+	case -EINPROGRESS:
+		break;
+	default:
+		__connman_service_ipconfig_indicate_state(service,
 						CONNMAN_SERVICE_STATE_FAILURE,
 						CONNMAN_IPCONFIG_TYPE_IPV4);
-			__connman_service_ipconfig_indicate_state(service,
+		__connman_service_ipconfig_indicate_state(service,
 						CONNMAN_SERVICE_STATE_FAILURE,
 						CONNMAN_IPCONFIG_TYPE_IPV6);
-		}
 	}
 
 	return err;

--- a/connman/vpn/plugins/vpn.c
+++ b/connman/vpn/plugins/vpn.c
@@ -834,11 +834,27 @@ static bool vpn_uses_vpn_agent(struct vpn_provider *provider)
 	return true;
 }
 
+static int vpn_get_flags(struct vpn_provider *provider)
+{
+	struct vpn_driver_data *vpn_driver_data = NULL;
+	const char *name = NULL;
+
+	if (!provider)
+		return 0;
+
+	name = vpn_provider_get_driver_name(provider);
+	vpn_driver_data = g_hash_table_lookup(driver_hash, name);
+	if (vpn_driver_data)
+		return vpn_driver_data->vpn_driver->flags;
+
+	return 0;
+}
+
 int vpn_register(const char *name, const struct vpn_driver *vpn_driver,
 			const char *program)
 {
 	struct vpn_driver_data *data;
-	
+
 	if (!name)
 		return -EINVAL;
 
@@ -863,6 +879,7 @@ int vpn_register(const char *name, const struct vpn_driver *vpn_driver,
 	data->provider_driver.set_state = vpn_set_state;
 	data->provider_driver.route_env_parse = vpn_route_env_parse;
 	data->provider_driver.uses_vpn_agent = vpn_uses_vpn_agent;
+	data->provider_driver.get_flags = vpn_get_flags;
 
 	if (!driver_hash)
 		driver_hash = g_hash_table_new_full(g_str_hash,

--- a/connman/vpn/plugins/wireguard.c
+++ b/connman/vpn/plugins/wireguard.c
@@ -957,7 +957,7 @@ static int disconnect(struct vpn_provider *provider, int err)
 	data->provider = provider;
 	data->err = err ? err : exit_code;
 
-	info->dying_id = g_timeout_add(1, wg_died, data);
+	info->dying_id = g_timeout_add(50, wg_died, data);
 
 	return exit_code;
 }

--- a/connman/vpn/plugins/wireguard.c
+++ b/connman/vpn/plugins/wireguard.c
@@ -231,7 +231,8 @@ static int parse_endpoint(const char *host, const char *port, struct sockaddr_u 
 	err = getaddrinfo(tokens[0], port, &hints, &result);
 	g_strfreev(tokens);
 
-	if (err < 0) {
+	/* Any non-zero return from getaddrinfo is an error */
+	if (err) {
 		DBG("Failed to resolve host address: %s", gai_strerror(err));
 		return -EINVAL;
 	}
@@ -250,8 +251,9 @@ static int parse_endpoint(const char *host, const char *port, struct sockaddr_u 
 	}
 
 	if (!rp) {
+		DBG("no connectable address found in results");
 		freeaddrinfo(result);
-		return -EINVAL;
+		return -EHOSTUNREACH;
 	}
 
 	memcpy(addr, rp->ai_addr, rp->ai_addrlen);
@@ -573,6 +575,7 @@ static gboolean wg_dns_reresolve_cb(gpointer user_data)
 		return G_SOURCE_REMOVE;
 	}
 
+	DBG("endpoint_fqdn %s", info->endpoint_fqdn);
 	info->resolv_id = vpn_util_resolve_hostname(info->resolv,
 						info->endpoint_fqdn,
 						resolve_endpoint_cb, info);
@@ -884,8 +887,15 @@ error:
 	 * looping when parameters are incorrect and VPN stays in failed
 	 * state.
 	 */
-	vpn_provider_add_error(provider, VPN_PROVIDER_ERROR_LOGIN_FAILED);
-	err = -ECONNABORTED;
+	if (err == -EHOSTUNREACH) {
+		vpn_provider_add_error(provider,
+					VPN_PROVIDER_ERROR_CONNECT_FAILED);
+	} else {
+		vpn_provider_add_error(provider,
+					VPN_PROVIDER_ERROR_LOGIN_FAILED);
+		err = -ECONNABORTED;
+	}
+
 	goto done;
 }
 

--- a/connman/vpn/vpn-provider.c
+++ b/connman/vpn/vpn-provider.c
@@ -126,7 +126,14 @@ static unsigned int get_connman_state_timeout;
 static guint connman_signal_watch;
 static guint connman_service_watch;
 
-static bool connman_online;
+enum connman_state {
+	CONNMAN_IDLE = 0,
+	CONNMAN_OFFLINE,
+	CONNMAN_READY,
+	CONNMAN_ONLINE
+};
+
+static enum connman_state connman_online_state = CONNMAN_IDLE;
 static bool state_query_completed;
 static char *connman_dbus_name = NULL;
 
@@ -166,22 +173,46 @@ static void set_state(const char *new_state)
 	if (!new_state || !*new_state)
 		return;
 
-	DBG("old state %s new state %s",
-				connman_online ?
-				CONNMAN_STATE_ONLINE "/" CONNMAN_STATE_READY :
-				CONNMAN_STATE_OFFLINE "/" CONNMAN_STATE_IDLE,
-				new_state);
+	DBG("received %s, old state %d", new_state, connman_online_state);
 
-	/* States "online" and "ready" mean connman is online */
-	if (!g_ascii_strcasecmp(new_state, CONNMAN_STATE_ONLINE) ||
-			!g_ascii_strcasecmp(new_state, CONNMAN_STATE_READY))
-		connman_online = true;
-	/* Everything else means connman is offline */
+	if (!g_ascii_strcasecmp(new_state, CONNMAN_STATE_ONLINE))
+		connman_online_state = CONNMAN_ONLINE;
+	else if (!g_ascii_strcasecmp(new_state, CONNMAN_STATE_READY))
+		connman_online_state = CONNMAN_READY;
+	else if (!g_ascii_strcasecmp(new_state, CONNMAN_STATE_OFFLINE))
+		connman_online_state = CONNMAN_OFFLINE;
 	else
-		connman_online = false;
+		connman_online_state = CONNMAN_IDLE;
 
-	DBG("set state %s connman_online=%s ", new_state,
-				connman_online ? "true" : "false");
+	DBG("new state %d ", connman_online_state);
+}
+
+static bool is_connman_connected(struct vpn_provider *provider)
+{
+	int flags = 0;
+
+	DBG("provider %p connmand state %d", provider, connman_online_state);
+
+	if (provider && provider->driver && provider->driver->get_flags)
+		flags = provider->driver->get_flags(provider);
+
+	switch (connman_online_state) {
+	case CONNMAN_IDLE:
+	case CONNMAN_OFFLINE:
+		return false;
+	case CONNMAN_READY:
+		/* VPNs without daemon may require that network is setup. */
+		if (flags & VPN_FLAG_NO_DAEMON) {
+			DBG("daemonless provider, return false in ready");
+			return false;
+		}
+
+		/* fall-through */
+	case CONNMAN_ONLINE:
+		break;
+	}
+
+	return true;
 }
 
 static void free_route(gpointer data)
@@ -870,8 +901,8 @@ static gboolean do_connect_timeout_function(gpointer data)
 
 	DBG("");
 
-	/* Keep in main loop if connman is not online. */
-	if (!connman_online)
+	/* Keep in main loop if connman is not ready for this VPN. */
+	if (!is_connman_connected(provider))
 		return G_SOURCE_CONTINUE;
 
 	provider->do_connect_timeout = 0;
@@ -951,7 +982,7 @@ static DBusMessage *do_connect(DBusConnection *conn, DBusMessage *msg,
 		return __connman_error_permission_denied(msg);
 	}
 
-	if (!connman_online) {
+	if (!is_connman_connected(provider)) {
 		if (state_query_completed) {
 			DBG("%s not started - ConnMan not online/ready",
 				provider->identifier);

--- a/connman/vpn/vpn-provider.c
+++ b/connman/vpn/vpn-provider.c
@@ -984,6 +984,15 @@ static DBusMessage *do_connect(DBusConnection *conn, DBusMessage *msg,
 
 	if (!is_connman_connected(provider)) {
 		if (state_query_completed) {
+			/* Query done but connmand not online for daemonless */
+			if (connman_online_state >= CONNMAN_READY) {
+				DBG("Provider %s start delayed, wait for "
+						"connman online state",
+						provider->identifier);
+				do_connect_later(provider, conn, msg);
+				return NULL;
+			}
+
 			DBG("%s not started - ConnMan not online/ready",
 				provider->identifier);
 			return __connman_error_failed(msg, ENOLINK);

--- a/connman/vpn/vpn-provider.h
+++ b/connman/vpn/vpn-provider.h
@@ -184,6 +184,7 @@ struct vpn_provider_driver {
 			int *family, unsigned long *idx,
 			enum vpn_provider_route_type *type);
 	bool (*uses_vpn_agent) (struct vpn_provider *provider);
+	int (*get_flags)(struct vpn_provider *provider);
 };
 
 int vpn_provider_driver_register(struct vpn_provider_driver *driver);


### PR DESCRIPTION
Changing network on certain devices seemed to make WireGuard quit connecting or looping quite a lot between connect->disconnect->idle->connect. These fixes address the problem of premature quitting in case the results from `getaddinfo()` cannot be connected yet by simply returning a non-terminal EHOSTUNREACH so WireGuard is attempted again with VPN autoconnect.

The connect-disconnect loop can be elimintated by increasing the delay of calling `wg_died()` when WireGuard is being disconnected. This could otherwise, with the 1ms delay, cause quite interesting behavior of connmand not having enough time to setup the routes as the interface disappears too fast because of some network condition not being set, which will then result in many attempts of connect and disconnect and having trouble in keeping the both daemons in sync with each other causing chaos and confusion. 50ms seems to be quite close what it may take for a daemon utilizing VPN to disconnect.

Reworked the connmand state tracking to have the exact state (idle, offline, ready and online) recorded. This allowed to have the behavior on the VPNs that have a daemon to be unchanged and to have only the daemonless (VPN_FLAG_NO_DAEMON) VPNs to be connected when the state is online.  This required adding a function to the internal VPN plugin that acts as the driver for launching VPNs for getting the flags set by the VPN plugin. By doing so, and adding a delayed start in case these VPNs are run at ready state, the daemonless VPNs are the only ones that are started when online state is reached. This should eliminate a bit of the unconnectable cases when resolving the address.

In addition, reverted a change for route setup that upstream has also reverted as being harmful.