### PR TITLE
Fix WireGuard FQDN hostname resolving

### DIFF
--- a/connman/src/provider.c
+++ b/connman/src/provider.c
@@ -475,6 +475,10 @@ static int set_connected(struct connman_provider *provider,
 			provider->driver->set_routes(provider,
 						CONNMAN_PROVIDER_ROUTE_ALL);
 
+		__connman_service_nameserver_add_routes(provider->vpn_service,
+					provider->driver->get_property(
+						provider, "HostIP"));
+
 	} else {
 		if (ipconfig_ipv4) {
 			provider_indicate_state(provider,

--- a/connman/src/shared/util.h
+++ b/connman/src/shared/util.h
@@ -25,7 +25,7 @@
 
 #include <glib.h>
 #include <stdbool.h>
-#include <inet.h>
+#include <arpa/inet.h>
 
 #define AF_INET_POS 0
 #define AF_INET6_POS 1

--- a/connman/vpn/plugins/wireguard.c
+++ b/connman/vpn/plugins/wireguard.c
@@ -248,10 +248,35 @@ static int get_endpoint_addr(const char *host, const char *port, int flags,
 	return 0;
 }
 
-static int parse_endpoint_hostname(const char *host, const char *port,
-							struct sockaddr_u *addr)
+static const char *endpoint_to_str(struct wg_peer *peer, char *buf,
+							socklen_t len)
 {
+	struct sockaddr_u *addr;
+	int family;
+
+	addr = (struct sockaddr_u *)&peer->endpoint.addr;
+	family = peer->endpoint.addr.sa_family;
+
+	switch (family) {
+	case AF_INET:
+		return inet_ntop(family, &addr->sin.sin_addr, buf, len);
+	case AF_INET6:
+		return inet_ntop(family, &addr->sin6.sin6_addr, buf, len);
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+static int parse_endpoint_hostname(const char *host, const char *port,
+							struct wg_peer *peer,
+							char **gateway_resolved)
+{
+	struct sockaddr_u *addr;
 	char **tokens;
+	const char *gw = NULL;
+	char buf[INET6_ADDRSTRLEN] = { 0 };
 	unsigned int len;
 	int err;
 
@@ -270,9 +295,20 @@ static int parse_endpoint_hostname(const char *host, const char *port,
 
 	DBG("using host %s", tokens[0]);
 
+	addr = (struct sockaddr_u *)&peer->endpoint.addr;
+
 	err = get_endpoint_addr(tokens[0], port, 0, addr);
-	if (!err)
+	if (!err) {
+		/* In case the endpoint is an host address use the resolved
+		 * IP address as gateway for DNS over WireGuard to work.
+		 */
+		if (connman_inet_check_ipaddress(tokens[0]) <= 0)
+			gw = endpoint_to_str(peer, buf, INET6_ADDRSTRLEN);
+
 		DBG("success");
+	}
+
+	*gateway_resolved = gw ? g_strdup(gw) : g_strdup(tokens[0]);
 
 	g_strfreev(tokens);
 
@@ -632,27 +668,6 @@ static gboolean wg_dns_reresolve_cb(gpointer user_data)
 	return G_SOURCE_REMOVE;
 }
 
-static const char *endpoint_to_str(struct wg_peer *peer, char *buf,
-							socklen_t len)
-{
-	struct sockaddr_u *addr;
-	int family;
-
-	addr = (struct sockaddr_u *)&peer->endpoint.addr;
-	family = peer->endpoint.addr.sa_family;
-
-	switch (family) {
-	case AF_INET:
-		return inet_ntop(family, &addr->sin.sin_addr, buf, len);
-	case AF_INET6:
-		return inet_ntop(family, &addr->sin6.sin6_addr, buf, len);
-	default:
-		break;
-	}
-
-	return NULL;
-}
-
 static gboolean wg_route_setup_cb(gpointer user_data)
 {
 	struct wireguard_info *info = user_data;
@@ -750,7 +765,9 @@ static int wg_connect(struct vpn_provider *provider,
 {
 	struct wg_ipaddresses ipaddresses = { 0 };
 	struct wireguard_info *info;
-	const char *option, *gateway;
+	const char *option;
+	const char *endpoint;
+	char *gateway = NULL;
 	char *ifname;
 	bool do_split_routing = true;
 	bool disable_ipv6 = false;
@@ -840,21 +857,20 @@ static int wg_connect(struct vpn_provider *provider,
 	if (!option)
 		option = "51820";
 
-	gateway = vpn_provider_get_string(provider, "Host");
+	endpoint = vpn_provider_get_string(provider, "Host");
 	/*
 	 * Use the resolve timeout only with re-resolve. Here the network
 	 * is setup as the transport is used. In succeeding attempts resolving
 	 * is needed as it is done over potentially misconfigured WireGuard
 	 * connection that may end up blocking vpnd with getaddrinfo().
 	 */
-	err = parse_endpoint_hostname(gateway, option,
-			(struct sockaddr_u *)&info->peer.endpoint.addr);
+	err = parse_endpoint_hostname(endpoint, option, &info->peer, &gateway);
 	if (err) {
-		DBG("Failed to parse endpoint %s:%s", gateway, option);
+		DBG("Failed to parse endpoint %s:%s", endpoint, option);
 		goto error;
 	}
 
-	info->endpoint_fqdn = g_strdup(gateway);
+	info->endpoint_fqdn = g_strdup(endpoint);
 	info->port = g_strdup(option);
 
 	option = vpn_provider_get_string(provider, "WireGuard.Address");
@@ -862,11 +878,14 @@ static int wg_connect(struct vpn_provider *provider,
 		DBG("Missing WireGuard.Address configuration");
 		goto error;
 	}
+
 	err = parse_addresses(option, gateway, &ipaddresses);
 	if (err) {
-		DBG("Failed to parse addresses %s gateway %s", option, gateway);
+		DBG("Failed to parse addresses %s endpoint %s gateway %s",
+						option, endpoint, gateway);
 		goto error;
 	}
+	g_free(gateway);
 
 	ifname = get_ifname();
 	if (!ifname) {

--- a/connman/vpn/plugins/wireguard.c
+++ b/connman/vpn/plugins/wireguard.c
@@ -668,9 +668,8 @@ static gboolean wg_route_setup_cb(gpointer user_data)
 	family = info->peer.endpoint.addr.sa_family;
 
 	if (!endpoint_to_str(&info->peer, endpoint, INET6_ADDRSTRLEN)) {
-		DBG("Faulty endpoint set, use endpoint_fqdn");
-		memcpy(&endpoint, info->endpoint_fqdn, INET6_ADDRSTRLEN);
-		family = connman_inet_check_ipaddress(info->endpoint_fqdn);
+		connman_warn("Cannot setup WireGuard routes, endpoint failure");
+		return G_SOURCE_REMOVE;
 	}
 
 	wg_for_each_allowedip(&info->peer, allowedip) {


### PR DESCRIPTION
This fixes the issue that WireGuard would not work if the endpoint (hostname) is a FQDN. The main cause was that the FQDN name was used as a gateway when adding routes, which is now using the resolved IP.

Also the code has changes to handle the initial resolve and the reresolve of the  endpoint differently. In the first case it utilizes `getaddrinfo()` to do the resolve but in the latter case GResolv does the resolving and the results do not need to be resolved again, just to fill the strutures with `getaddrinfo()` with `AI_NUMERICHOST`.

Changed also to start the DNS reresolve only when there is a FQDN defined as entpoint.