### PR TITLE
Add option for setting default mDNS value for all new Ethernet/WLAN services

### DIFF
--- a/connman/doc/connman.conf.5.in
+++ b/connman/doc/connman.conf.5.in
@@ -224,6 +224,7 @@ Path to localtime file. Defaults to /etc/localtime.
 Enable regdomain to be changed along timezone changes. With this option set to
 true each time the timezone changes the first present ISO3166 country code is
 being read from /usr/share/zoneinfo/zone1970.tab and set as regdom value.
+.TP
 .BI OnlineCheckInitialInterval= secs, OnlineCheckMaxInterval= secs
 Range of intervals between two online check requests.
 When an online check request fails, another one is triggered after a
@@ -233,6 +234,13 @@ Default range is [1, 12], corresponding to the following intervals, in
 seconds: 1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121 and 144.
 .TP
 Default value is false.
+.TP
+.BI DefaultmDNSConfiguration= true\ \fR|\fB\ false
+The default mDNS value for all new ethernet and WiFi services. Other type
+servcies are not affected.
+.TP
+Default value is false.
+.TP
 .SH "EXAMPLE"
 The following example configuration disables hostname updates and enables
 ethernet tethering.

--- a/connman/include/setting.h
+++ b/connman/include/setting.h
@@ -67,6 +67,7 @@ extern "C" {
 #define CONF_ENABLE_LOGIN_MANAGER            "EnableLoginManager"
 #define CONF_LOCALTIME                       "Localtime"
 #define CONF_REGDOM_FOLLOWS_TIMEZONE         "RegdomFollowsTimezone"
+#define CONF_DEFAULT_MDNS_CONFIGURATION      "DefaultmDNSConfiguration"
 
 #define CONF_ONLINE_CHECK_INITIAL_INTERVAL   "OnlineCheckInitialInterval"
 #define CONF_ONLINE_CHECK_MAX_INTERVAL       "OnlineCheckMaxInterval"

--- a/connman/src/setting.c
+++ b/connman/src/setting.c
@@ -114,6 +114,7 @@ static struct {
 	bool use_gateways_as_timeservers;
 	bool enable_login_manager;
 	bool regdom_follows_timezone;
+	bool default_mdns_configuration;
 	mode_t storage_root_permissions;
 	mode_t storage_dir_permissions;
 	mode_t storage_file_permissions;
@@ -166,6 +167,7 @@ enum option_val {
 	CONF_ENABLE_LOGIN_MANAGER_VAL,
 	CONF_LOCALTIME_VAL,
 	CONF_REGDOM_FOLLOWS_TIMEZONE_VAL,
+	CONF_DEFAULT_MDNS_CONFIGURATION_VAL,
 	CONF_ONLINE_CHECK_INITIAL_INTERVAL_VAL,
 	CONF_ONLINE_CHECK_MAX_INTERVAL_VAL
 };
@@ -295,6 +297,9 @@ struct {
 	{CONF_REGDOM_FOLLOWS_TIMEZONE,
 					CONF_REGDOM_FOLLOWS_TIMEZONE_VAL,
 					CONF_TYPE_BOOL},
+	{CONF_DEFAULT_MDNS_CONFIGURATION,
+					CONF_DEFAULT_MDNS_CONFIGURATION_VAL,
+					CONF_TYPE_BOOL},
 	{CONF_ONLINE_CHECK_INITIAL_INTERVAL,
 					CONF_ONLINE_CHECK_INITIAL_INTERVAL_VAL,
 					CONF_TYPE_INT},
@@ -413,6 +418,9 @@ bool connman_setting_get_bool(const char *key)
 
 	if (g_str_equal(key, CONF_REGDOM_FOLLOWS_TIMEZONE))
 		return connman_settings.regdom_follows_timezone;
+
+	if (g_str_equal(key, CONF_DEFAULT_MDNS_CONFIGURATION))
+		return connman_settings.default_mdns_configuration;
 
 	return false;
 }
@@ -770,6 +778,9 @@ static void read_config_value(GKeyFile *config, const char *key, bool append)
 		break;
 	case CONF_REGDOM_FOLLOWS_TIMEZONE_VAL:
 		bool_ptr = &connman_settings.regdom_follows_timezone;
+		break;
+	case CONF_DEFAULT_MDNS_CONFIGURATION_VAL:
+		bool_ptr = &connman_settings.default_mdns_configuration;
 		break;
 
 	/* str */


### PR DESCRIPTION
Add option to settings to define a default value for mDNS and document it.

Since the "false" mDNS value is dropped from the service file, so there is no knowledge if the user has disabled it explicitly and that is why the value is set only for new services. Otherwise each load of the service would set the system override for old services, from which mDNS was disabled - assuming system setting is "true".

Adding only to Ethernet and WLAN for now.

This has changes from the other PRs https://github.com/sailfishos/connman/pull/100 and https://github.com/sailfishos/connman/pull/101 included to ease testing.