### PR TITLE
Support setting mDNS on the tethering network

### DIFF
--- a/connman/include/setting.h
+++ b/connman/include/setting.h
@@ -68,6 +68,7 @@ extern "C" {
 #define CONF_LOCALTIME                       "Localtime"
 #define CONF_REGDOM_FOLLOWS_TIMEZONE         "RegdomFollowsTimezone"
 #define CONF_DEFAULT_MDNS_CONFIGURATION      "DefaultmDNSConfiguration"
+#define CONF_TETHERING_MDNS_CONFIGURATION    "TetheringmDNSConfiguration"
 
 #define CONF_ONLINE_CHECK_INITIAL_INTERVAL   "OnlineCheckInitialInterval"
 #define CONF_ONLINE_CHECK_MAX_INTERVAL       "OnlineCheckMaxInterval"

--- a/connman/src/setting.c
+++ b/connman/src/setting.c
@@ -115,6 +115,7 @@ static struct {
 	bool enable_login_manager;
 	bool regdom_follows_timezone;
 	bool default_mdns_configuration;
+	bool tethering_mdns_configuration;
 	mode_t storage_root_permissions;
 	mode_t storage_dir_permissions;
 	mode_t storage_file_permissions;
@@ -168,6 +169,7 @@ enum option_val {
 	CONF_LOCALTIME_VAL,
 	CONF_REGDOM_FOLLOWS_TIMEZONE_VAL,
 	CONF_DEFAULT_MDNS_CONFIGURATION_VAL,
+	CONF_TETHERING_MDNS_CONFIGURATION_VAL,
 	CONF_ONLINE_CHECK_INITIAL_INTERVAL_VAL,
 	CONF_ONLINE_CHECK_MAX_INTERVAL_VAL
 };
@@ -300,6 +302,9 @@ struct {
 	{CONF_DEFAULT_MDNS_CONFIGURATION,
 					CONF_DEFAULT_MDNS_CONFIGURATION_VAL,
 					CONF_TYPE_BOOL},
+	{CONF_TETHERING_MDNS_CONFIGURATION,
+					CONF_TETHERING_MDNS_CONFIGURATION_VAL,
+					CONF_TYPE_BOOL},
 	{CONF_ONLINE_CHECK_INITIAL_INTERVAL,
 					CONF_ONLINE_CHECK_INITIAL_INTERVAL_VAL,
 					CONF_TYPE_INT},
@@ -421,6 +426,9 @@ bool connman_setting_get_bool(const char *key)
 
 	if (g_str_equal(key, CONF_DEFAULT_MDNS_CONFIGURATION))
 		return connman_settings.default_mdns_configuration;
+
+	if (g_str_equal(key, CONF_TETHERING_MDNS_CONFIGURATION))
+		return connman_settings.tethering_mdns_configuration;
 
 	return false;
 }
@@ -781,6 +789,9 @@ static void read_config_value(GKeyFile *config, const char *key, bool append)
 		break;
 	case CONF_DEFAULT_MDNS_CONFIGURATION_VAL:
 		bool_ptr = &connman_settings.default_mdns_configuration;
+		break;
+	case CONF_TETHERING_MDNS_CONFIGURATION_VAL:
+		bool_ptr = &connman_settings.tethering_mdns_configuration;
 		break;
 
 	/* str */

--- a/connman/src/tethering.c
+++ b/connman/src/tethering.c
@@ -418,6 +418,12 @@ int __connman_tethering_set_enabled(void)
 		DBG("Cannot setup IPv6 prefix delegation %d/%s", err,
 			strerror(-err));
 
+	if (connman_setting_get_bool(CONF_TETHERING_MDNS_CONFIGURATION)) {
+		err = __connman_dnsproxy_set_mdns(index, true);
+		if (err)
+			connman_warn("Cannot enable mDNS for tethering");
+	}
+
 	DBG("tethering started");
 
 	return 0;
@@ -431,6 +437,10 @@ void __connman_tethering_set_disabled(void)
 
 	if (__sync_fetch_and_sub(&tethering_enabled, 1) != 1)
 		return;
+
+	/* Ignore errors as interface is being put down */
+	if (connman_setting_get_bool(CONF_TETHERING_MDNS_CONFIGURATION))
+		__connman_dnsproxy_set_mdns(index, false);
 
 	unregister_all_clients();
 


### PR DESCRIPTION
Add a configuration option to enable mDNS for the tethering network.