### PR TITLE
[dnsproxy] Address CVE-2025-32366 vulnerability. Fixes JB#63369

### DIFF
--- a/connman/src/dnsproxy.c
+++ b/connman/src/dnsproxy.c
@@ -998,6 +998,9 @@ static int parse_rr(const unsigned char *buf, const unsigned char *start,
 	if ((offset + *rdlen) > *response_size)
 		return -ENOBUFS;
 
+	if ((*end + *rdlen) > max)
+		return -EINVAL;
+
 	memcpy(response + offset, *end, *rdlen);
 
 	*end += *rdlen;


### PR DESCRIPTION
Apply upstream fix for CVE-2025-32366 to dnsproxy.c.

Now that we use resolved this does not apply to us, and the `parse_rr` is only on the cache side of  `dnsproxy.c` so it does not affect the `shared/dns.c`.