### PR TITLE
Use _psk suffix for all WPA-supporting WLAN networks to avoid duplicate named networks

### DIFF
--- a/connman/plugins/sailfish_wifi.c
+++ b/connman/plugins/sailfish_wifi.c
@@ -65,7 +65,7 @@
 
 #define WIFI_BSS_COUNT_SMALL (10)
 #define WIFI_BSS_COUNT_MAX (100)
-#define WIFI_WEAK_RSSI (-85) /* dBm */
+#define WIFI_WEAK_RSSI (-75) /* dBm */
 #define WIFI_WEAK_RSSI_MAX (-65) /* dBm */
 #define WIFI_WEAK_BSS_MIN_SIGHTINGS (3)
 

--- a/connman/plugins/sailfish_wifi.c
+++ b/connman/plugins/sailfish_wifi.c
@@ -1104,6 +1104,18 @@ static GSupplicantBSS *wifi_network_current_bss(struct wifi_network *net)
 	return NULL;
 }
 
+static void wifi_network_save_network_param(struct wifi_network *net,
+							const char *param)
+{
+	struct connman_service *service =
+		connman_service_lookup_from_network(net->network);
+
+	if (__connman_service_update_value_from_network(service, net->network,
+								param)) {
+		__connman_service_save(service);
+	}
+}
+
 static void wifi_network_update_bssid(struct wifi_network *net)
 {
 	GSupplicantBSS *bss = wifi_network_current_bss(net);
@@ -1115,6 +1127,13 @@ static void wifi_network_update_bssid(struct wifi_network *net)
 
 		if (bssid_len == WIFI_BSSID_LEN) {
 			connman_network_set_bssid(net->network, bssid_data);
+			/* Update also the security to be signaled over D-Bus */
+			connman_network_set_string(net->network,
+					NETWORK_KEY_WIFI_SECURITY,
+					__connman_service_security2string_real(
+						wifi_bss_security(bss)));
+			wifi_network_save_network_param(net,
+					NETWORK_KEY_WIFI_SECURITY);
 			return;
 		}
 	}
@@ -1185,18 +1204,6 @@ static void wifi_network_update_wps_caps_from_bss(struct wifi_network *net,
 				(wps & (GSUPPLICANT_WPS_PUSH_BUTTON |
 					GSUPPLICANT_WPS_PIN)) &&
 				(wps & GSUPPLICANT_WPS_REGISTRAR));
-}
-
-static void wifi_network_save_network_param(struct wifi_network *net,
-							const char *param)
-{
-	struct connman_service *service =
-		connman_service_lookup_from_network(net->network);
-
-	if (__connman_service_update_value_from_network(service, net->network,
-								param)) {
-		__connman_service_save(service);
-	}
 }
 
 static void wifi_network_init_add_blob(GHashTable **blobs, const char *name,
@@ -1750,7 +1757,8 @@ static void wifi_network_init(struct wifi_network *net, struct wifi_bss *data)
 								data, len);
 	}
 	connman_network_set_string(net->network, NETWORK_KEY_WIFI_SECURITY,
-		 __connman_service_security2string(wifi_bss_security(bss)));
+		 __connman_service_security2string_real(
+		 	wifi_bss_security(bss)));
 	if (gsupplicant_bss_security(bss) == GSUPPLICANT_SECURITY_EAP) {
 		/*
 		 * update_from_network() will replace the special default
@@ -1759,6 +1767,7 @@ static void wifi_network_init(struct wifi_network *net, struct wifi_bss *data)
 		connman_network_set_string(net->network, NETWORK_KEY_WIFI_EAP,
 					NETWORK_EAP_DEFAULT);
 	}
+	wifi_network_save_network_param(net, NETWORK_KEY_WIFI_SECURITY);
 
 	wifi_network_update_wps_caps_from_bss(net, bss);
 	connman_network_set_frequency(net->network, bss->frequency);

--- a/connman/src/agent-connman.c
+++ b/connman/src/agent-connman.c
@@ -255,6 +255,12 @@ static void request_input_append_passphrase(DBusMessageIter *iter,
 	case CONNMAN_SERVICE_SECURITY_PSK:
 		value = "psk";
 		break;
+	case CONNMAN_SERVICE_SECURITY_PSK_SAE:
+		value = "psksae";
+		break;
+	case CONNMAN_SERVICE_SECURITY_SAE:
+		value = "sae";
+		break;
 	case CONNMAN_SERVICE_SECURITY_8021X:
 		phase2 = __connman_service_get_phase2(service);
 
@@ -381,7 +387,7 @@ static void previous_passphrase_handler(DBusMessageIter *iter,
 			return;
 
 		security = __connman_service_get_security(service);
-		data.type = __connman_service_security2string(security);
+		data.type = __connman_service_security2string_real(security);
 		if (!data.type)
 			return;
 	}

--- a/connman/src/config.c
+++ b/connman/src/config.c
@@ -790,10 +790,9 @@ static bool load_service(GKeyFile *keyfile, const char *group,
 
 	str = __connman_config_get_string(keyfile, group, SERVICE_KEY_SECURITY,
 			NULL);
-	security = __connman_service_string2security(str);
+	security = __connman_service_string2security_real(str);
 
 	if (service->eap) {
-
 		if (str && security != CONNMAN_SERVICE_SECURITY_8021X)
 			connman_info("Mismatch between EAP configuration and "
 					"setting %s = %s",
@@ -802,12 +801,15 @@ static bool load_service(GKeyFile *keyfile, const char *group,
 		service->security = CONNMAN_SERVICE_SECURITY_8021X;
 
 	} else if (service->passphrase) {
-
 		if (str) {
-			if (security == CONNMAN_SERVICE_SECURITY_PSK ||
-					security == CONNMAN_SERVICE_SECURITY_WEP) {
+			switch (security) {
+			case CONNMAN_SERVICE_SECURITY_PSK:
+			case CONNMAN_SERVICE_SECURITY_PSK_SAE:
+			case CONNMAN_SERVICE_SECURITY_SAE:
+			case CONNMAN_SERVICE_SECURITY_WEP:
 				service->security = security;
-			} else {
+				break;
+			default:
 				connman_info("Mismatch with passphrase and "
 						"setting %s = %s",
 						SERVICE_KEY_SECURITY, str);
@@ -1330,7 +1332,8 @@ static int try_provision_service(struct connman_config_service *config,
 			return -ENOENT;
 
 		str = connman_network_get_string(network, "WiFi.Security");
-		if (config->security != __connman_service_string2security(str))
+		if (config->security != __connman_service_string2security_real(
+									str))
 			return -ENOENT;
 
 		break;

--- a/connman/src/connman.h
+++ b/connman/src/connman.h
@@ -941,6 +941,9 @@ enum connman_service_type __connman_service_string2type(const char *str);
 enum connman_service_security __connman_service_string2security(const char *str);
 const char *__connman_service_security2string(enum connman_service_security security);
 
+const char *__connman_service_security2string_real(enum connman_service_security security);
+enum connman_service_security __connman_service_string2security_real(const char *str);
+
 int __connman_service_nameserver_append(struct connman_service *service,
 				const char *nameserver, bool is_auto);
 int __connman_service_nameserver_remove(struct connman_service *service,
@@ -995,6 +998,8 @@ void __connman_service_set_agent_identity(struct connman_service *service,
 						const char *agent_identity);
 int __connman_service_set_passphrase(struct connman_service *service,
 					const char *passphrase);
+void __connman_service_set_security(struct connman_service *service,
+					enum connman_service_security security);
 const char *__connman_service_get_passphrase(struct connman_service *service);
 int __connman_service_check_passphrase(enum connman_service_security security,
 					const char *passphrase);

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -631,6 +631,53 @@ enum connman_service_security __connman_service_string2security(const char *str)
 	if (!strcmp(str, "wep"))
 		return CONNMAN_SERVICE_SECURITY_WEP;
 	if (!strcmp(str,"psksae"))
+		return CONNMAN_SERVICE_SECURITY_PSK;
+	if (!strcmp(str,"sae"))
+		return CONNMAN_SERVICE_SECURITY_PSK;
+
+	return CONNMAN_SERVICE_SECURITY_UNKNOWN;
+}
+
+const char *__connman_service_security2string(enum connman_service_security security)
+{
+	switch (security) {
+	case CONNMAN_SERVICE_SECURITY_UNKNOWN:
+		break;
+	case CONNMAN_SERVICE_SECURITY_NONE:
+		return "none";
+	case CONNMAN_SERVICE_SECURITY_WEP:
+		return "wep";
+	case CONNMAN_SERVICE_SECURITY_PSK:
+	case CONNMAN_SERVICE_SECURITY_WPA:
+	case CONNMAN_SERVICE_SECURITY_RSN:
+	case CONNMAN_SERVICE_SECURITY_PSK_SAE:
+	case CONNMAN_SERVICE_SECURITY_SAE:
+		return "psk";
+	case CONNMAN_SERVICE_SECURITY_8021X:
+		return "ieee8021x";
+	}
+
+	return NULL;
+}
+
+enum connman_service_security __connman_service_string2security_real(const char *str)
+{
+	if (!str)
+		return CONNMAN_SERVICE_SECURITY_UNKNOWN;
+
+	if (!strcmp(str, "psk"))
+		return CONNMAN_SERVICE_SECURITY_PSK;
+	if (!strcmp(str, "ieee8021x") || !strcmp(str, "8021x"))
+		return CONNMAN_SERVICE_SECURITY_8021X;
+	if (!strcmp(str, "none") || !strcmp(str, "open"))
+		return CONNMAN_SERVICE_SECURITY_NONE;
+	if (!strcmp(str, "wep"))
+		return CONNMAN_SERVICE_SECURITY_WEP;
+	if (!strcmp(str, "wpa"))
+		return CONNMAN_SERVICE_SECURITY_WPA;
+	if (!strcmp(str, "rsn"))
+		return CONNMAN_SERVICE_SECURITY_RSN;
+	if (!strcmp(str,"psksae"))
 		return CONNMAN_SERVICE_SECURITY_PSK_SAE; // WPA2+WPA3
 	if (!strcmp(str,"sae"))
 		return CONNMAN_SERVICE_SECURITY_SAE;
@@ -638,7 +685,8 @@ enum connman_service_security __connman_service_string2security(const char *str)
 	return CONNMAN_SERVICE_SECURITY_UNKNOWN;
 }
 
-const char *__connman_service_security2string(enum connman_service_security security)
+const char *__connman_service_security2string_real(
+					enum connman_service_security security)
 {
 	switch (security) {
 	case CONNMAN_SERVICE_SECURITY_UNKNOWN:
@@ -1139,7 +1187,20 @@ static int service_save(struct connman_service *service)
 			freq = connman_network_get_frequency(service->network);
 			g_key_file_set_integer(keyfile, service->identifier,
 						"Frequency", freq);
+			cst_str = connman_network_get_string(service->network,
+					"WiFi.Security");
 		}
+		
+		if (!cst_str)
+			cst_str = __connman_service_security2string_real(
+							service->security);
+
+		DBG("service %s security %s", service->identifier, cst_str);
+			
+		set_config_string(keyfile, service->identifier,
+				"Security", cst_str);
+		cst_str = NULL;
+
 		set_config_string(keyfile, service->identifier,
 			PROP_EAP, service->eap);
 		set_config_string(keyfile, service->identifier,
@@ -2412,7 +2473,7 @@ static void append_security(DBusMessageIter *iter, void *user_data)
 	struct connman_service *service = user_data;
 	const char *str;
 
-	str = __connman_service_security2string(service->security);
+	str = __connman_service_security2string_real(service->security);
 	if (str)
 		dbus_message_iter_append_basic(iter,
 				DBUS_TYPE_STRING, &str);
@@ -4353,6 +4414,39 @@ const char *__connman_service_get_passphrase(struct connman_service *service)
 		return NULL;
 
 	return service->passphrase;
+}
+
+static gboolean set_security(struct connman_service *service,
+					enum connman_service_security security)
+{
+	if (!service || service->security == security)
+		return FALSE;
+
+	service->security = security;
+	security_changed(service);
+	return TRUE;
+}
+
+static gboolean set_security_str(struct connman_service *service,
+					const char *security)
+{
+	if (!security)
+		return FALSE;
+
+	return set_security(service,
+			__connman_service_string2security_real(security));
+}
+
+void __connman_service_set_security(struct connman_service *service,
+					enum connman_service_security security)
+{
+	if (!service)
+		return;
+
+	if (service->immutable || service->hidden)
+		return;
+
+	set_security(service, security);
 }
 
 /*
@@ -9316,7 +9410,7 @@ static enum connman_service_security security_from_ident(const char *ident)
 		}
 	}
 
-	return __connman_service_string2security(str);
+	return __connman_service_string2security_real(str);
 }
 
 static bool service_default_mdns(enum connman_service_type type)
@@ -9955,30 +10049,6 @@ static enum connman_service_type convert_network_type(struct connman_network *ne
 	return CONNMAN_SERVICE_TYPE_UNKNOWN;
 }
 
-static enum connman_service_security convert_wifi_security(const char *security)
-{
-	if (!security)
-		return CONNMAN_SERVICE_SECURITY_UNKNOWN;
-	else if (g_str_equal(security, "none"))
-		return CONNMAN_SERVICE_SECURITY_NONE;
-	else if (g_str_equal(security, "wep"))
-		return CONNMAN_SERVICE_SECURITY_WEP;
-	else if (g_str_equal(security, "psk"))
-		return CONNMAN_SERVICE_SECURITY_PSK;
-	else if (g_str_equal(security, "ieee8021x"))
-		return CONNMAN_SERVICE_SECURITY_8021X;
-	else if (g_str_equal(security, "wpa"))
-		return CONNMAN_SERVICE_SECURITY_WPA;
-	else if (g_str_equal(security, "rsn"))
-		return CONNMAN_SERVICE_SECURITY_RSN;
-	else if (g_str_equal(security, "psksae"))
-		return CONNMAN_SERVICE_SECURITY_PSK_SAE;
-	else if (g_str_equal(security, "sae"))
-		return CONNMAN_SERVICE_SECURITY_SAE;
-	else
-		return CONNMAN_SERVICE_SECURITY_UNKNOWN;
-}
-
 static void update_wps_values(struct connman_service *service,
 				struct connman_network *network)
 {
@@ -10028,6 +10098,9 @@ gboolean __connman_service_update_value_from_network(
 			}
 		}
 		return FALSE;
+	} else if (!g_strcmp0(key, "WiFi.Security")) {
+		return set_security_str(service, connman_network_get_string(
+								network, key));
 	} else {
 		return TRUE;
 	}
@@ -10103,14 +10176,13 @@ static void update_from_network(struct connman_service *service,
 		service->strength = strength;
 	}
 
-	str = connman_network_get_string(network, "WiFi.Security");
-	service->security = convert_wifi_security(str);
-
 	if (service->type == CONNMAN_SERVICE_TYPE_WIFI) {
 		__connman_service_update_value_from_network(service, network,
-								"WiFi.SSID");
+							"WiFi.Security");
 		__connman_service_update_value_from_network(service, network,
-								"WiFi.EAP");
+							"WiFi.SSID");
+		__connman_service_update_value_from_network(service, network,
+							"WiFi.EAP");
 		update_wps_values(service, network);
 	}
 
@@ -10356,12 +10428,20 @@ void __connman_service_update_from_network(struct connman_network *network)
 roaming:
 	roaming = connman_network_get_bool(service->network, "Roaming");
 	if (roaming == service->roaming)
-		goto sorting;
+		goto security;
 
 	service->roaming = roaming;
 	need_sort = true;
 
 	roaming_changed(service);
+
+security:
+	/* Calls security_changed() if security changes */
+	if (!set_security_str(service, connman_network_get_string(
+					service->network, "WiFi.Security")))
+		goto sorting;
+
+	need_sort = true;
 
 sorting:
 	if (need_sort) {

--- a/connman/src/storage.c
+++ b/connman/src/storage.c
@@ -1178,53 +1178,73 @@ static GKeyFile *storage_wpa2_to_wpa3_transition_check(const char *service_id)
 	GKeyFile *keyfile_to_clone = NULL;
 	gsize len;
 	gchar **keys;
+	char *suffixes[] = { "_psksae", "_sae", NULL };
 	char *pos;
 	char *search_id = NULL;
 	int i;
 
-	if (!g_str_has_suffix(service_id, "_psksae") &&
-					!g_str_has_suffix(service_id, "_sae"))
+	if (!g_str_has_suffix(service_id, "_psk"))
 		return NULL;
 
 	DBG("Search WiFi _psk settings for %s", service_id);
 
-	search_id = g_strdup(service_id);
-	pos = strrchr(search_id, '_');
-	if (!pos || strlen(pos) < 4) // Make sure we don't do buffer overflow
-		goto out;
-
-	stpncpy(pos, "_psk", strlen(pos) + 1); // Pad the remaining with \0
-
-	DBG("Search id %s", search_id);
-
-	keyfile_to_clone = connman_storage_load_service(search_id);
-	if (!keyfile_to_clone) {
-		DBG("No old settings for %s", service_id);
-		goto out;
-	}
-
-	keys = g_key_file_get_keys(keyfile_to_clone, search_id, &len, NULL);
-	if (!keys) {
-		DBG("No keys set in %s", search_id);
-		goto out;
-	}
-
-	DBG("Convert %s to %s", search_id, service_id);
-
-	keyfile = g_key_file_new();
 	
-	for (i = 0; i < len; i++)
-		g_key_file_set_string(keyfile, service_id, keys[i],
-				g_key_file_get_string(keyfile_to_clone, search_id, keys[i], NULL));
+	pos = strrchr(service_id, '_');
+	if (!pos)
+		goto out;
 
-	g_strfreev(keys);
+	size_t copy_len = strlen(service_id) - strlen(pos);
 
-	if (__connman_storage_save_service(keyfile, service_id)) {
-		connman_warn("Cannot save cloned service %s, keeping old %s",
-							service_id, search_id);
-	} else {
-		DBG("Removing old service %s", search_id);
-		__connman_storage_remove_service(search_id);
+	for (i = 0; suffixes[i]; i++) {
+		size_t suf_len = strlen(suffixes[i]) + 1;
+		search_id = (char*)g_malloc0((copy_len + suf_len) *
+								sizeof(char));
+		stpncpy(search_id, service_id, copy_len);
+		stpncpy(search_id+copy_len, suffixes[i], suf_len);
+
+		DBG("Search id %s", search_id);
+
+		keyfile_to_clone = connman_storage_load_service(search_id);
+		if (!keyfile_to_clone) {
+			DBG("No old settings for %s", service_id);
+			g_free(search_id);
+			search_id = NULL;
+			continue;
+		}
+
+		keys = g_key_file_get_keys(keyfile_to_clone, search_id, &len,
+						NULL);
+		if (!keys) {
+			DBG("No keys set in %s", search_id);
+			g_free(search_id);
+			search_id = NULL;
+
+			if (keyfile_to_clone)
+				g_key_file_unref(keyfile_to_clone);
+
+			continue;
+		}
+
+		DBG("Convert %s to %s", search_id, service_id);
+
+		keyfile = g_key_file_new();
+		
+		for (i = 0; i < len; i++)
+			g_key_file_set_string(keyfile, service_id, keys[i],
+					g_key_file_get_string(keyfile_to_clone, search_id, keys[i], NULL));
+
+		g_strfreev(keys);
+
+		if (__connman_storage_save_service(keyfile, service_id)) {
+			connman_warn("Cannot save cloned service %s, keeping old %s",
+								service_id, search_id);
+		} else {
+			DBG("Removing old service %s", search_id);
+			__connman_storage_remove_service(search_id);
+		}
+
+		// Found, break out of loop
+		break;
 	}
 
 out:

--- a/connman/unit/test-setting.c
+++ b/connman/unit/test-setting.c
@@ -171,6 +171,11 @@ enum connman_service_security __connman_service_string2security(const char *str)
 	return 0;
 }
 
+enum connman_service_security __connman_service_string2security_real(const char *str)
+{
+	return 0;
+}
+
 enum connman_service_type __connman_service_string2type(const char *str)
 {
 	if (!str)


### PR DESCRIPTION
Use the `_psk` for all WiFi networks having any WPA-security. This avoids having duplicate networks in the list if the networks are extended with other APs. To achieve this the BSSID creation, update or change does also the security parameter update. The real, accurate, WPA-type is used for D-Bus and for the WiFi driver. 