### PR TITLE
Persist offline power policy per tech.

### DIFF
--- a/connman/doc/connmanctl.1.in
+++ b/connman/doc/connmanctl.1.in
@@ -69,9 +69,10 @@ technology and disconnects if it is already connected.
 .PP
 .TP
 .B enable offline
-Enables offline mode. Disconnects and powers down all
-technologies system-wide, however each technology can be powered
-back on individually.
+Enables offline mode. Disconnects and powers down the
+technologies configured to be powered down in offline mode.
+Ethernet and GPS keep their current power state by default, and
+each technology can be powered back on individually.
 .PP
 .TP
 .B disable offline

--- a/connman/doc/manager-api.txt
+++ b/connman/doc/manager-api.txt
@@ -315,15 +315,21 @@ Properties	string State [readonly]
 		boolean OfflineMode [readwrite]
 
 			The offline mode indicates the global setting for
-			switching all radios on or off. Changing offline mode
-			to true results in powering down all devices. When
-			leaving offline mode the individual policy of each
-			device decides to switch the radio back on or not.
+			switching technologies into or out of offline mode.
+			Changing offline mode to true powers down the
+			technologies configured to be powered down in offline
+			mode. Ethernet and GPS are not powered down by
+			default. When leaving offline mode the individual
+			policy of each device decides to switch the radio
+			back on or not.
 
 			During offline mode, it is still possible to switch
 			certain technologies manually back on. For example
 			the limited usage of WiFi or Bluetooth devices might
-			be allowed in some situations.
+			be allowed in some situations. Power changes made
+			through the Technology Powered property while offline
+			mode is active are remembered for future offline mode
+			transitions.
 
 		boolean SessionMode [readwrite]  [experminental][deprecated]
 

--- a/connman/doc/overview-api.txt
+++ b/connman/doc/overview-api.txt
@@ -413,10 +413,13 @@ User can use the Technology Powered property to turn on or off a given
 technology. See doc/technology-api.txt document for details.
 
 User can activate offline (flight) mode via Manager OfflineMode property.
-While in offline mode, all the technologies including ethernet are
-powered off. During the offline mode, the user can temporarily activate
+While in offline mode, technologies configured to be powered down in
+offline mode are powered off. Ethernet and GPS keep their current power
+state by default. During the offline mode, the user can change
 individual technologies by using the Technology Powered property or by
 using the rfkill command or Fn-Fx key combination found in some laptops.
+Power changes made through the Technology Powered property while offline
+mode is active are remembered for future offline mode transitions.
 
 If the host supports rfkill switch, then all the radios can be turned off
 by the kernel when the switch is activated. ConnMan will notice this and

--- a/connman/doc/technology-api.txt
+++ b/connman/doc/technology-api.txt
@@ -52,6 +52,11 @@ Properties	boolean Powered [readwrite]
 			off (and is available RF-Killed) while True means
 			that the technology is enabled.
 
+			When this property is changed while the Manager
+			OfflineMode property is true, ConnMan also remembers
+			whether the technology should be powered down the
+			next time offline mode is entered.
+
 		boolean Connected [readonly]
 
 			Boolean representing if a technology is connected.

--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -78,6 +78,7 @@ struct connman_technology {
 	char *tethering_passphrase;
 
 	bool enable_persistent; /* Save the tech state */
+	bool disable_in_offlinemode; /* Save if offline mode powers it off */
 
 	GSList *driver_list;
 
@@ -178,6 +179,74 @@ static const char *get_name(enum connman_service_type type)
 	return NULL;
 }
 
+static bool technology_default_disable_in_offlinemode(
+		enum connman_service_type type)
+{
+	switch (type) {
+	/*
+	 * Technologies that do not transmit radio signals should
+	 * stay on by default.
+	 */
+	case CONNMAN_SERVICE_TYPE_ETHERNET:
+	case CONNMAN_SERVICE_TYPE_GPS:
+	case CONNMAN_SERVICE_TYPE_GADGET:
+		return false;
+	/*
+	 * These types are not offline-mode-managed technologies.
+	 */
+	case CONNMAN_SERVICE_TYPE_UNKNOWN:
+	case CONNMAN_SERVICE_TYPE_SYSTEM:
+	case CONNMAN_SERVICE_TYPE_VPN:
+		return false;
+	/*
+	 * All transmitting radio technologies are powered down by default.
+	 */
+	case CONNMAN_SERVICE_TYPE_WIFI:
+	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
+	case CONNMAN_SERVICE_TYPE_CELLULAR:
+	case CONNMAN_SERVICE_TYPE_P2P:
+		return true;
+	}
+
+	return true;
+}
+
+static bool technology_disable_in_offlinemode(
+		struct connman_technology *technology)
+{
+	return technology && technology->disable_in_offlinemode;
+}
+
+static bool technology_persistent_powered(
+		struct connman_technology *technology, bool offlinemode)
+{
+	if (!technology)
+		return false;
+
+	return technology->enable_persistent &&
+		(!offlinemode || !technology_disable_in_offlinemode(technology));
+}
+
+static void technology_set_persistent_powered(
+		struct connman_technology *technology, bool powered)
+{
+	if (!technology)
+		return;
+
+	if (global_offlinemode) {
+		technology->disable_in_offlinemode = !powered;
+
+		/*
+		 * Enabling a technology in offline mode should also make it
+		 * stay enabled when returning to normal mode.
+		 */
+		if (powered)
+			technology->enable_persistent = true;
+	} else {
+		technology->enable_persistent = powered;
+	}
+}
+
 static void technology_save(struct connman_technology *technology)
 {
 	GKeyFile *keyfile;
@@ -199,6 +268,9 @@ static void technology_save(struct connman_technology *technology)
 
 	g_key_file_set_boolean(keyfile, identifier, "Enable",
 				technology->enable_persistent);
+
+	g_key_file_set_boolean(keyfile, identifier, "DisableInOfflineMode",
+				technology->disable_in_offlinemode);
 
 	g_key_file_set_boolean(keyfile, identifier, "Tethering",
 				technology->tethering_persistent);
@@ -487,6 +559,18 @@ static int technology_load_values(struct connman_technology *technology,
 	}
 
 	enable = g_key_file_get_boolean(keyfile, identifier,
+					"DisableInOfflineMode", &error);
+	if (!error) {
+		technology->disable_in_offlinemode = enable;
+	} else {
+		technology->disable_in_offlinemode =
+			technology_default_disable_in_offlinemode(
+						technology->type);
+		need_saving = true;
+		g_clear_error(&error);
+	}
+
+	enable = g_key_file_get_boolean(keyfile, identifier,
 					"Tethering", &error);
 	if (!error) {
 		technology->tethering_persistent = enable;
@@ -523,6 +607,9 @@ static void technology_load(struct connman_technology *technology)
 			technology->enable_persistent = true;
 		else
 			technology->enable_persistent = false;
+		technology->disable_in_offlinemode =
+			technology_default_disable_in_offlinemode(
+						technology->type);
 		return;
 	}
 
@@ -863,7 +950,9 @@ static int technology_enabled(struct connman_technology *technology)
 		struct connman_technology *p2p;
 
 		p2p = technology_find(CONNMAN_SERVICE_TYPE_P2P);
-		if (p2p && !p2p->enabled && p2p->enable_persistent)
+		if (p2p && !p2p->enabled &&
+				technology_persistent_powered(p2p,
+						global_offlinemode))
 			technology_enabled(p2p);
 	}
 
@@ -904,7 +993,7 @@ static int technology_enable(struct connman_technology *technology)
 	if (technology->pending_reply)
 		return -EBUSY;
 
-	if (connman_setting_get_bool("PersistentTetheringMode")	&&
+	if (connman_setting_get_bool("PersistentTetheringMode") &&
 					technology->tethering)
 		set_tethering(technology, true);
 
@@ -1028,8 +1117,7 @@ static gboolean enable_delayed(gpointer user_data)
 	switch (err) {
 	case -EBUSY:
 		/* Make sure the pending reply does not block and continue */
-		if (technology_send_pending_reply(technology, -ECANCELED) ==
-					-ECOMM)
+		if (technology_send_pending_reply(technology, -ECANCELED) == -ECOMM)
 			connman_warn("could not reply to pending request");
 
 		return G_SOURCE_CONTINUE;
@@ -1094,7 +1182,7 @@ static DBusMessage *set_powered(struct connman_technology *technology,
 		err = technology_disable(technology);
 
 	if (err != -EBUSY) {
-		technology->enable_persistent = powered;
+		technology_set_persistent_powered(technology, powered);
 		technology_save(technology);
 	} else if (powered && err == -EBUSY) {
 		technology_init_enable_delayed(technology);
@@ -1141,9 +1229,9 @@ static DBusMessage *set_property(DBusConnection *conn,
 	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_VARIANT)
 		return __connman_error_invalid_arguments(msg);
 
-	if (__connman_access_tech_set_property(get_tech_access_policy(),
-		name, dbus_message_get_sender(msg), CONNMAN_ACCESS_ALLOW) !=
-						CONNMAN_ACCESS_ALLOW) {
+	if (__connman_access_tech_set_property(get_tech_access_policy(), name,
+					dbus_message_get_sender(msg), CONNMAN_ACCESS_ALLOW) !=
+			CONNMAN_ACCESS_ALLOW) {
 		DBG("%s is not allowed to set %s",
 				dbus_message_get_sender(msg), name);
 		return __connman_error_permission_denied(msg);
@@ -1518,7 +1606,8 @@ static struct connman_technology *technology_get(enum connman_service_type type)
 		struct connman_technology *wifi;
 		bool enable;
 
-		enable = technology->enable_persistent;
+		enable = technology_persistent_powered(technology,
+						global_offlinemode);
 
 		wifi = technology_find(CONNMAN_SERVICE_TYPE_WIFI);
 		if (enable && wifi)
@@ -1738,8 +1827,7 @@ int __connman_technology_add_device(struct connman_device *device)
 		goto done;
 	}
 
-	if (technology->enable_persistent &&
-					!global_offlinemode) {
+	if (technology_persistent_powered(technology, global_offlinemode)) {
 		int err = __connman_device_enable(device);
 		/*
 		 * connman_technology_add_device() calls __connman_device_enable()
@@ -1749,10 +1837,9 @@ int __connman_technology_add_device(struct connman_device *device)
 		 */
 		if (err == -EALREADY)
 			__connman_technology_enabled(type);
-	}
-	/* if technology persistent state is offline */
-	if (!technology->enable_persistent)
+	} else {
 		__connman_device_disable(device);
+	}
 
 done:
 	technology->device_list = g_slist_prepend(technology->device_list,
@@ -1831,10 +1918,23 @@ int __connman_technology_disabled(enum connman_service_type type)
 	return technology_disabled(technology);
 }
 
+static bool technology_offlinemode_result_ok(int err)
+{
+	switch (err) {
+	case 0:
+	case -EALREADY:
+	case -EINPROGRESS:
+	case -EOPNOTSUPP:
+		return true;
+	}
+
+	return false;
+}
+
 int __connman_technology_set_offlinemode(bool offlinemode)
 {
 	GSList *list;
-	int err = -EINVAL, enabled_tech_count = 0;
+	int fatal_err = 0;
 
 	if (global_offlinemode == offlinemode)
 		return 0;
@@ -1864,55 +1964,55 @@ int __connman_technology_set_offlinemode(bool offlinemode)
 	/* Traverse technology list, enable/disable each technology. */
 	for (list = technology_list; list; list = list->next) {
 		struct connman_technology *technology = list->data;
+		int err;
 
 		if (offlinemode) {
+			if (!technology_disable_in_offlinemode(technology))
+				continue;
+
 			err = technology_disable(technology);
+			if (technology_offlinemode_result_ok(err))
+				continue;
+
+			if (!fatal_err)
+				fatal_err = err;
 			continue;
 		}
 
 		if (technology->hardblocked)
 			continue;
 
-		if (!offlinemode && (technology->enable_persistent ||
-					technology->type ==
-					CONNMAN_SERVICE_TYPE_CELLULAR)) {
-			err = technology_enable(technology);
-			switch (err) {
-			case -EINPROGRESS:
-			case -EALREADY:
-			case 0:
-				enabled_tech_count++;
-				break;
-			case -EBUSY:
-				technology_init_enable_delayed(technology);
-				break;
-			default:
-				break;
-			}
+		if (!technology->enable_persistent &&
+				technology->type !=
+				CONNMAN_SERVICE_TYPE_CELLULAR)
+			continue;
+
+		err = technology_enable(technology);
+		if (err == -EBUSY) {
+			err = technology_init_enable_delayed(technology);
+			if (err == 0 || err == -EALREADY)
+				err = -EINPROGRESS;
 		}
+
+		if (technology_offlinemode_result_ok(err))
+			continue;
+
+		DBG("tech %p/%s failed to enable, result %s",
+				technology, get_name(technology->type),
+				strerror(-err));
 	}
 
-	switch (err) {
-	case -EINVAL:
-		if (enabled_tech_count > 0)
-			break;
-
-	case -EINPROGRESS:
-		/* fall through */
-	case -EALREADY:
-		/* fall through */
-	case 0:
+	if (!offlinemode || !fatal_err) {
 		connman_technology_save_offlinemode();
 		__connman_notifier_offlinemode(offlinemode);
-		break;
-	default:
+	} else {
 		global_offlinemode = connman_technology_load_offlinemode();
 	}
 
 	DBG("Clearing offlinemode override bitmask.");
 	global_offlinemode_override = 0;
 
-	return err;
+	return offlinemode ? fatal_err : 0;
 }
 
 void __connman_technology_set_connected(enum connman_service_type type,
@@ -2064,9 +2164,8 @@ bool __connman_technology_enable_from_config()
 
 		if (technology->rfkill_driven && technology->hardblocked) {
 			DBG("technology %p/%s hardblocked, not set as %s",
-						technology,
-						get_name(technology->type),
-						technology->enable_persistent ?
+					technology, get_name(technology->type),
+					technology_persistent_powered(technology, offlinemode) ?
 						"enabled" : "disabled");
 			technology_save(technology);
 			continue;
@@ -2077,39 +2176,7 @@ bool __connman_technology_enable_from_config()
 					technology->enable_persistent ?
 					"enabled" : "disabled");
 
-		if (!technology->enable_persistent) {
-			if (!technology->enabled) {
-				DBG("tech %p/%s already disabled", technology,
-						get_name(technology->type));
-				continue;
-			}
-
-			err = technology_disable(technology);
-			if (!err) {
-				if (technology_changed_state(technology,
-							false))
-					connman_warn("technology %p state"
-							"change not notified",
-							technology);
-			}
-
-			DBG("tech %p/%s enabled set as disabled, result %s",
-						technology,
-						get_name(technology->type),
-						err ? strerror(-err) : "ok");
-		} else {
-			/*
-			 * Don't enable in offline mode but set
-			 * enable_persistent to make sure tech is enabled
-			 * when leaving offline mode.
-			*/
-			if (offlinemode) {
-				DBG("tech %p/%s not enabled in offlinemode",
-						technology,
-						get_name(technology->type));
-				continue;
-			}
-
+		if (technology_persistent_powered(technology, offlinemode)) {
 			if (technology->enabled) {
 				DBG("tech %p/%s already enabled", technology,
 						get_name(technology->type));
@@ -2121,25 +2188,46 @@ bool __connman_technology_enable_from_config()
 			 * delayed to avoid inconsistent state.
 			 */
 			if (technology->rfkill_driven) {
-				err = technology_init_enable_delayed(
-							technology);
+				err = technology_init_enable_delayed(technology);
 			} else {
 				err = technology_enable(technology);
 				if (!err) {
-					if (technology_changed_state(
-							technology, true))
+					if (technology_changed_state(technology, true))
 						connman_warn("tech %p state"
 							"change notify fail",
 							technology);
 				} else if (err == -EBUSY) {
-					technology_init_enable_delayed(
-								technology);
+					technology_init_enable_delayed(technology);
 				}
 			}
 
 			DBG("tech %p/%s disabled set as enabled, result %s",
-						technology,
-						get_name(technology->type),
+						technology, get_name(technology->type),
+						err ? strerror(-err) : "ok");
+		} else {
+			if (!technology->enabled) {
+				if (offlinemode &&
+						technology->enable_persistent &&
+						technology_disable_in_offlinemode(technology)) {
+					DBG("tech %p/%s not enabled in offlinemode",
+							technology, get_name(technology->type));
+				} else if (!technology->enable_persistent) {
+					DBG("tech %p/%s already disabled",
+							technology, get_name(technology->type));
+				}
+
+				continue;
+			}
+
+			err = technology_disable(technology);
+			if (!err) {
+				if (technology_changed_state(technology, false))
+					connman_warn("technology %p state"
+							"change not notified", technology);
+			}
+
+			DBG("tech %p/%s enabled set as disabled, result %s",
+						technology, get_name(technology->type),
 						err ? strerror(-err) : "ok");
 		}
 
@@ -2155,9 +2243,9 @@ bool __connman_technology_enable_from_config()
 }
 
 static bool technology_apply_rfkill_change(struct connman_technology *technology,
-						bool softblock,
-						bool hardblock,
-						bool new_rfkill)
+											bool softblock,
+											bool hardblock,
+											bool new_rfkill)
 {
 	bool hardblock_changed = false;
 	bool apply = true;
@@ -2201,12 +2289,10 @@ softblock_change:
 
 	technology->softblocked = softblock;
 
-	if (technology->hardblocked ||
-					technology->softblocked) {
+	if (technology->hardblocked || technology->softblocked) {
 		if (technology_disabled(technology) != -EALREADY)
 			technology_affect_devices(technology, false);
-	} else if (!technology->hardblocked &&
-					!technology->softblocked) {
+	} else if (!technology->hardblocked && !technology->softblocked) {
 		if (technology_enabled(technology) != -EALREADY)
 			technology_affect_devices(technology, true);
 	}
@@ -2219,7 +2305,8 @@ softblock_change:
 			DBG("%s is switched on.", get_name(technology->type));
 			technology_dbus_register(technology);
 
-			if (global_offlinemode)
+			if (global_offlinemode &&
+					technology_disable_in_offlinemode(technology))
 				__connman_rfkill_block(technology->type, true);
 		}
 	}
@@ -2228,9 +2315,9 @@ softblock_change:
 }
 
 int __connman_technology_add_rfkill(unsigned int index,
-					enum connman_service_type type,
-						bool softblock,
-						bool hardblock)
+									enum connman_service_type type,
+									bool softblock,
+									bool hardblock)
 {
 	struct connman_technology *technology;
 	struct connman_rfkill *rfkill;
@@ -2268,15 +2355,15 @@ done:
 
 	/*
 	 * Depending on softblocked state we unblock/block according to
-	 * offlinemode and persistente state.
+	 * offlinemode policy and persistent state.
 	 */
 	if (technology->softblocked &&
-				!global_offlinemode &&
-				technology->enable_persistent)
+			technology_persistent_powered(technology,
+						global_offlinemode))
 		return __connman_rfkill_block(type, false);
 	else if (!technology->softblocked &&
-		(global_offlinemode ||
-				!technology->enable_persistent)) {
+			!technology_persistent_powered(technology,
+						global_offlinemode)) {
 		/* Don't block for technologies which have been enabled
 		   since offlinemode was turned on */
 		if (global_offlinemode_override & (1 << type))
@@ -2289,9 +2376,9 @@ done:
 }
 
 int __connman_technology_update_rfkill(unsigned int index,
-					enum connman_service_type type,
-						bool softblock,
-						bool hardblock)
+										enum connman_service_type type,
+										bool softblock,
+										bool hardblock)
 {
 	struct connman_technology *technology;
 	struct connman_rfkill *rfkill;
@@ -2314,8 +2401,7 @@ int __connman_technology_update_rfkill(unsigned int index,
 	if (!technology)
 		return -ENXIO;
 
-	technology_apply_rfkill_change(technology, softblock, hardblock,
-								false);
+	technology_apply_rfkill_change(technology, softblock, hardblock, false);
 
 	if (technology->hardblocked)
 		DBG("%s hardblocked", get_name(technology->type));

--- a/connman/unit/test-storage.c
+++ b/connman/unit/test-storage.c
@@ -565,6 +565,47 @@ static struct connman_device test_device3 = {
 	.scanning = false,
 };
 
+static int test_device1_enable_err;
+static int test_device1_disable_err;
+static int test_device2_enable_err;
+static int test_device2_disable_err;
+
+static int *get_test_device_err_ptr(struct connman_device *device, bool enable)
+{
+	if (device == &test_device1)
+		return enable ? &test_device1_enable_err :
+				&test_device1_disable_err;
+
+	if (device == &test_device2)
+		return enable ? &test_device2_enable_err :
+				&test_device2_disable_err;
+
+	return NULL;
+}
+
+static void set_test_device_err(struct connman_device *device, bool enable,
+				int err)
+{
+	int *err_ptr = get_test_device_err_ptr(device, enable);
+
+	g_assert(err_ptr);
+	*err_ptr = err;
+}
+
+static int consume_test_device_err(struct connman_device *device, bool enable)
+{
+	int *err_ptr = get_test_device_err_ptr(device, enable);
+	int err = 0;
+
+	if (!err_ptr)
+		return 0;
+
+	err = *err_ptr;
+	*err_ptr = 0;
+
+	return err;
+}
+
 int __connman_device_request_scan(enum connman_service_type type)
 {
 	return 0;
@@ -626,10 +667,16 @@ bool connman_device_get_powered(struct connman_device *device)
 
 int __connman_device_enable(struct connman_device *device)
 {
+	int err;
+
 	DBG("device %p:%s", device, device->ident);
 
 	if (!device)
 		return -EINVAL;
+
+	err = consume_test_device_err(device, true);
+	if (err)
+		return err;
 
 	if (device->enabled)
 		return -EALREADY;
@@ -641,10 +688,16 @@ int __connman_device_enable(struct connman_device *device)
 
 int __connman_device_disable(struct connman_device *device)
 {
+	int err;
+
 	DBG("device %p:%s", device, device->ident);
 
 	if (!device)
 		return -EINVAL;
+
+	err = consume_test_device_err(device, false);
+	if (err)
+		return err;
 
 	if (!device->enabled)
 		return -EALREADY;
@@ -1354,9 +1407,11 @@ static void storage_test_global2()
 				"",
 				"[WiFi]",
 				"Enable=true",
+				"DisableInOfflineMode=false",
 				"",
 				"[Cellular]",
 				"Enable=false",
+				"DisableInOfflineMode=true",
 				"",
 				NULL,
 	};
@@ -1395,10 +1450,18 @@ static void storage_test_global2()
 
 	g_assert_true(g_key_file_has_key(keyfile, "WiFi", "Enable", NULL));
 	g_assert_true(g_key_file_get_boolean(keyfile, "WiFi", "Enable", NULL));
+	g_assert_true(g_key_file_has_key(keyfile, "WiFi",
+				"DisableInOfflineMode", NULL));
+	g_assert_false(g_key_file_get_boolean(keyfile, "WiFi",
+				"DisableInOfflineMode", NULL));
 
 	g_assert_true(g_key_file_has_key(keyfile, "Cellular", "Enable", NULL));
 	g_assert_false(g_key_file_get_boolean(keyfile, "Cellular", "Enable",
 				NULL));
+	g_assert_true(g_key_file_has_key(keyfile, "Cellular",
+				"DisableInOfflineMode", NULL));
+	g_assert_true(g_key_file_get_boolean(keyfile, "Cellular",
+				"DisableInOfflineMode", NULL));
 
 	/* Save and verify content */
 	g_assert_cmpint(__connman_storage_save_global(keyfile), ==, 0);
@@ -5587,10 +5650,12 @@ static void storage_test_technology_callbacks3()
 				"OfflineMode=true",
 				"",
 				"[WiFi]",
-				"Enable=false",
+				"Enable=true",
+				"DisableInOfflineMode=false",
 				"",
 				"[Cellular]",
 				"Enable=true",
+				"DisableInOfflineMode=true",
 				"",
 				NULL,
 	};
@@ -5677,7 +5742,7 @@ static void storage_test_technology_callbacks3()
 	/* user2 has offline mode enabled */
 	change_user_connmand_only(UID_USER2);
 	g_assert_false(test_device1.enabled);
-	g_assert_false(test_device2.enabled);
+	g_assert_true(test_device2.enabled);
 	g_assert_true(__connman_technology_get_offlinemode());
 
 	DBG("remove devices and drivers");
@@ -5690,7 +5755,7 @@ static void storage_test_technology_callbacks3()
 				-ENXIO);
 
 	set_technology_powered(CONNMAN_SERVICE_TYPE_WIFI, false,
-				"net.connman.Error.AlreadyDisabled");
+				NULL);
 	g_assert_cmpint(__connman_technology_remove_device(&test_device2), ==,
 				0);
 	connman_technology_driver_unregister(&test_device2_driver);

--- a/connman/unit/test-storage.c
+++ b/connman/unit/test-storage.c
@@ -5707,6 +5707,291 @@ static void storage_test_technology_callbacks3()
 	g_free(test_path);
 }
 
+static void storage_test_technology_callbacks4()
+{
+	gchar *test_path;
+	gchar *settings_file;
+	mode_t m_dir = 0700;
+	mode_t m_file = 0600;
+	GKeyFile *keyfile;
+	gchar *content[] = {
+				"[global]",
+				"OfflineMode=false",
+				"",
+				"[WiFi]",
+				"Enable=true",
+				"DisableInOfflineMode=true",
+				"",
+				"[Cellular]",
+				"Enable=true",
+				"DisableInOfflineMode=true",
+				"",
+				NULL,
+	};
+
+	test_path = setup_test_directory();
+
+	init_dbus(TRUE);
+
+	g_assert_cmpint(__connman_storage_init(test_path, test_user_dir, m_dir,
+								m_file), ==, 0);
+	g_assert_cmpint(__connman_storage_create_dir(STORAGEDIR,
+				__connman_storage_dir_mode()), ==, 0);
+
+	__connman_inotify_init();
+
+	settings_file = g_build_filename(STORAGEDIR, "settings", NULL);
+	set_and_verify_content(settings_file, content);
+
+	__connman_technology_init();
+
+	g_assert_cmpint(connman_technology_driver_register(
+				&test_device1_driver), ==, 0);
+	g_assert_cmpint(connman_technology_driver_register(
+				&test_device2_driver), ==, 0);
+
+	g_assert_cmpint(__connman_technology_add_device(&test_device1), ==, 0);
+	g_assert_true(test_device1.enabled);
+
+	g_assert_cmpint(__connman_technology_add_device(&test_device2), ==, 0);
+	g_assert_true(test_device2.enabled);
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_CELLULAR, true, NULL);
+	g_assert_cmpint(__connman_technology_enabled(
+				CONNMAN_SERVICE_TYPE_CELLULAR), ==, 0);
+	g_assert_true(test_device1.enabled);
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_WIFI, true, NULL);
+	g_assert_cmpint(__connman_technology_enabled(
+				CONNMAN_SERVICE_TYPE_WIFI), ==, 0);
+	g_assert_true(test_device2.enabled);
+
+	g_assert_cmpint(__connman_technology_set_offlinemode(true), ==, 0);
+	g_assert_true(__connman_technology_get_offlinemode());
+	g_assert_cmpint(__connman_technology_disabled(
+				CONNMAN_SERVICE_TYPE_CELLULAR), ==, 0);
+	g_assert_cmpint(__connman_technology_disabled(
+				CONNMAN_SERVICE_TYPE_WIFI), ==, 0);
+	g_assert_false(test_device1.enabled);
+	g_assert_false(test_device2.enabled);
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_WIFI, true, NULL);
+	g_assert_cmpint(__connman_technology_enabled(
+				CONNMAN_SERVICE_TYPE_WIFI), ==, 0);
+	g_assert_true(test_device2.enabled);
+
+	g_assert((keyfile = __connman_storage_load_global()));
+	g_assert_true(g_key_file_has_key(keyfile, "WiFi",
+				"DisableInOfflineMode", NULL));
+	g_assert_false(g_key_file_get_boolean(keyfile, "WiFi",
+				"DisableInOfflineMode", NULL));
+	g_key_file_unref(keyfile);
+
+	g_assert_cmpint(__connman_technology_set_offlinemode(false), ==, 0);
+	g_assert_false(__connman_technology_get_offlinemode());
+	g_assert_cmpint(__connman_technology_enabled(
+				CONNMAN_SERVICE_TYPE_CELLULAR), ==, 0);
+	g_assert_true(test_device1.enabled);
+	g_assert_true(test_device2.enabled);
+
+	g_assert_cmpint(__connman_technology_set_offlinemode(true), ==, 0);
+	g_assert_true(__connman_technology_get_offlinemode());
+	g_assert_cmpint(__connman_technology_disabled(
+					CONNMAN_SERVICE_TYPE_CELLULAR), ==, 0);
+	g_assert_false(test_device1.enabled);
+	g_assert_true(test_device2.enabled);
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_WIFI, false, NULL);
+	g_assert_cmpint(__connman_technology_disabled(
+					CONNMAN_SERVICE_TYPE_WIFI), ==, 0);
+	g_assert_false(test_device2.enabled);
+
+	g_assert((keyfile = __connman_storage_load_global()));
+	g_assert_true(g_key_file_get_boolean(keyfile, "WiFi", "Enable", NULL));
+	g_assert_true(g_key_file_get_boolean(keyfile, "WiFi",
+					"DisableInOfflineMode", NULL));
+	g_key_file_unref(keyfile);
+
+	g_assert_cmpint(__connman_technology_set_offlinemode(false), ==, 0);
+	g_assert_false(__connman_technology_get_offlinemode());
+	g_assert_cmpint(__connman_technology_enabled(
+					CONNMAN_SERVICE_TYPE_CELLULAR), ==, 0);
+	g_assert_true(test_device2.enabled);
+	g_assert_cmpint(__connman_technology_enabled(
+					CONNMAN_SERVICE_TYPE_WIFI), ==, 0);
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_CELLULAR, false, NULL);
+	g_assert_cmpint(__connman_technology_remove_device(&test_device1), ==,
+					0);
+	connman_technology_driver_unregister(&test_device1_driver);
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_WIFI, false, NULL);
+	g_assert_cmpint(__connman_technology_remove_device(&test_device2), ==,
+				0);
+	connman_technology_driver_unregister(&test_device2_driver);
+
+	__connman_technology_cleanup();
+	__connman_storage_cleanup();
+	__connman_inotify_cleanup();
+
+	clean_dbus();
+	cleanup_test_directory(test_path);
+
+	g_free(settings_file);
+	g_free(test_path);
+}
+
+static void storage_test_technology_callbacks5()
+{
+	gchar *test_path;
+	gchar *settings_file;
+	mode_t m_dir = 0700;
+	mode_t m_file = 0600;
+	GKeyFile *keyfile;
+	gchar *content[] = {
+				"[global]",
+				"OfflineMode=false",
+				"",
+				"[WiFi]",
+				"Enable=true",
+				"DisableInOfflineMode=true",
+				"",
+				NULL,
+	};
+
+	test_path = setup_test_directory();
+
+	init_dbus(TRUE);
+
+	g_assert_cmpint(__connman_storage_init(test_path, test_user_dir, m_dir,
+								m_file), ==, 0);
+	g_assert_cmpint(__connman_storage_create_dir(STORAGEDIR,
+				__connman_storage_dir_mode()), ==, 0);
+
+	__connman_inotify_init();
+
+	settings_file = g_build_filename(STORAGEDIR, "settings", NULL);
+	set_and_verify_content(settings_file, content);
+
+	__connman_technology_init();
+
+	g_assert_cmpint(connman_technology_driver_register(
+				&test_device2_driver), ==, 0);
+	g_assert_cmpint(__connman_technology_add_device(&test_device2), ==, 0);
+	g_assert_true(test_device2.enabled);
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_WIFI, true, NULL);
+	g_assert_cmpint(__connman_technology_enabled(
+				CONNMAN_SERVICE_TYPE_WIFI), ==, 0);
+	g_assert_true(test_device2.enabled);
+
+	set_test_device_err(&test_device2, false, -EOPNOTSUPP);
+	g_assert_cmpint(__connman_technology_set_offlinemode(true), ==, 0);
+	g_assert_true(__connman_technology_get_offlinemode());
+	g_assert_true(test_device2.enabled);
+
+	g_assert((keyfile = __connman_storage_load_global()));
+	g_assert_true(g_key_file_has_key(keyfile, "global", "OfflineMode",
+				NULL));
+	g_assert_true(g_key_file_get_boolean(keyfile, "global", "OfflineMode",
+				NULL));
+	g_key_file_unref(keyfile);
+
+	g_assert_cmpint(__connman_technology_set_offlinemode(false), ==, 0);
+	g_assert_false(__connman_technology_get_offlinemode());
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_WIFI, false, NULL);
+	g_assert_cmpint(__connman_technology_remove_device(&test_device2), ==,
+				0);
+	connman_technology_driver_unregister(&test_device2_driver);
+
+	__connman_technology_cleanup();
+	__connman_storage_cleanup();
+	__connman_inotify_cleanup();
+
+	clean_dbus();
+	cleanup_test_directory(test_path);
+
+	g_free(settings_file);
+	g_free(test_path);
+}
+
+static void storage_test_technology_callbacks6()
+{
+	gchar *test_path;
+	gchar *settings_file;
+	mode_t m_dir = 0700;
+	mode_t m_file = 0600;
+	GKeyFile *keyfile;
+	gchar *content[] = {
+					"[global]",
+					"OfflineMode=false",
+					"",
+					"[WiFi]",
+					"Enable=false",
+					"DisableInOfflineMode=false",
+					"",
+					NULL,
+	};
+
+	test_path = setup_test_directory();
+
+	init_dbus(TRUE);
+
+	g_assert_cmpint(__connman_storage_init(test_path, test_user_dir, m_dir,
+								m_file), ==, 0);
+	g_assert_cmpint(__connman_storage_create_dir(STORAGEDIR,
+					__connman_storage_dir_mode()), ==, 0);
+
+	__connman_inotify_init();
+
+	settings_file = g_build_filename(STORAGEDIR, "settings", NULL);
+	set_and_verify_content(settings_file, content);
+
+	__connman_technology_init();
+
+	g_assert_cmpint(connman_technology_driver_register(
+					&test_device2_driver), ==, 0);
+	g_assert_cmpint(__connman_technology_add_device(&test_device2), ==, 0);
+	g_assert_false(test_device2.enabled);
+
+	g_assert_cmpint(__connman_technology_set_offlinemode(true), ==, 0);
+	g_assert_true(__connman_technology_get_offlinemode());
+	g_assert_false(test_device2.enabled);
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_WIFI, true, NULL);
+	g_assert_cmpint(__connman_technology_enabled(
+					CONNMAN_SERVICE_TYPE_WIFI), ==, 0);
+	g_assert_true(test_device2.enabled);
+
+	g_assert((keyfile = __connman_storage_load_global()));
+	g_assert_true(g_key_file_get_boolean(keyfile, "WiFi", "Enable", NULL));
+	g_assert_false(g_key_file_get_boolean(keyfile, "WiFi",
+					"DisableInOfflineMode", NULL));
+	g_key_file_unref(keyfile);
+
+	g_assert_cmpint(__connman_technology_set_offlinemode(false), ==, 0);
+	g_assert_false(__connman_technology_get_offlinemode());
+	g_assert_true(test_device2.enabled);
+
+	g_assert_cmpint(__connman_technology_set_offlinemode(true), ==, 0);
+	g_assert_true(__connman_technology_get_offlinemode());
+	g_assert_true(test_device2.enabled);
+
+	set_technology_powered(CONNMAN_SERVICE_TYPE_WIFI, false, NULL);
+	g_assert_cmpint(__connman_technology_remove_device(&test_device2), ==, 0);
+	connman_technology_driver_unregister(&test_device2_driver);
+
+	__connman_technology_cleanup();
+	__connman_storage_cleanup();
+	__connman_inotify_cleanup();
+
+	clean_dbus();
+	cleanup_test_directory(test_path);
+
+	g_free(settings_file);
+	g_free(test_path);
+}
 static void storage_test_path_validation_error1()
 {
 	GKeyFile *keyfile;
@@ -5987,6 +6272,12 @@ int main(int argc, char **argv)
 				storage_test_technology_callbacks2);
 	g_test_add_func(TEST_PREFIX "/test_technology_callbacks3",
 				storage_test_technology_callbacks3);
+	g_test_add_func(TEST_PREFIX "/test_technology_callbacks4",
+				storage_test_technology_callbacks4);
+	g_test_add_func(TEST_PREFIX "/test_technology_callbacks5",
+				storage_test_technology_callbacks5);
+	g_test_add_func(TEST_PREFIX "/test_technology_callbacks6",
+				storage_test_technology_callbacks6);
 	g_test_add_func(TEST_PREFIX "/test_path_validation_error1",
 				storage_test_path_validation_error1);
 	g_test_add_func(TEST_PREFIX "/test_path_validation_error2",


### PR DESCRIPTION
If a technology is powered on in offline mode, remember that for next time. Initial behaviour is to turn off for everything except Ethernet and GPS, which aren't radio transmitting technologies.