### PR TITLE
Make new service suffix to always be psk and save real security type

### DIFF
--- a/connman/src/manager.c
+++ b/connman/src/manager.c
@@ -440,6 +440,7 @@ static DBusMessage *create_service(DBusConnection *conn, DBusMessage *msg,
 	DBusMessage *reply;
 	DBusMessageIter iter, array, entry;
 	enum connman_service_type service_type;
+	enum connman_service_security security_type;
 	GKeyFile *settings;
 	const char *sender = dbus_message_get_sender(msg);
 	const char *device_ident, *network_ident, *type = NULL, *name = NULL;
@@ -595,16 +596,21 @@ static DBusMessage *create_service(DBusConnection *conn, DBusMessage *msg,
 			return __connman_error_invalid_arguments(msg);
 		}
 
-		if (__connman_service_string2security(security) ==
-					CONNMAN_SERVICE_SECURITY_UNKNOWN) {
+		/* Map the security to the real type. */
+		security_type = __connman_service_string2security_real(security);
+		if (security_type == CONNMAN_SERVICE_SECURITY_UNKNOWN) {
 			DBG("invalid security %s", security);
 			g_free(tmp_name);
 			g_free(tmp_ssid);
 			return __connman_error_invalid_arguments(msg);
 		}
 
+		/* Get the ident and file suffix for the security type. */
 		ident = g_strconcat(type, "_", device_ident, "_",
-					ssid, "_managed_", security, NULL);
+					ssid, "_managed_",
+					__connman_service_security2string(
+								security_type),
+					NULL);
 	}
 
 	/* Lowercase the identifier */
@@ -627,6 +633,13 @@ static DBusMessage *create_service(DBusConnection *conn, DBusMessage *msg,
 		g_key_file_set_string(settings, ident, key, value);
 		dbus_message_iter_next(&array);
 	}
+
+	/*
+	 * Add also the security type to settings similar when expecting to
+	 * load a keyfile from the filesystem.
+	 */
+	if (security)
+		g_key_file_set_string(settings, ident, "Security", security);
 
 	/*
 	 * Make sure both Name and SSID are in there (one of them may have

--- a/connman/src/service.c
+++ b/connman/src/service.c
@@ -901,6 +901,9 @@ int __connman_service_load_modifiable(struct connman_service *service)
 	return 0;
 }
 
+static gboolean set_security_str(struct connman_service *service,
+					const char *security);
+
 static void service_apply(struct connman_service *service, GKeyFile *keyfile)
 {
 	GError *error = NULL;
@@ -959,6 +962,14 @@ static void service_apply(struct connman_service *service, GKeyFile *keyfile)
 				}
 			}
 			g_free(str);
+		}
+
+		str = g_key_file_get_string(keyfile, service->identifier,
+							"Security", NULL);
+		if (str) {
+			if (!set_security_str(service, str))
+				DBG("Cannot apply security str %s to %s",
+						str, service->identifier);
 		}
 
 		if (service->ssid && service->network &&


### PR DESCRIPTION
The new services were saved with wrong service suffix making the services to be saved with the suffix as well, hence ident is automatically created using that one. All WiFi services from WPA2 to WPA3 SAE have the same `_psk` suffix for ident, this must be kept but the security is now applied and notified properly so the new networks have the security type user selected.