### PR TITLE
Support wmtWifi type device tethering on Sailfish OS WiFi plugin

### DIFF
--- a/connman/include/setting.h
+++ b/connman/include/setting.h
@@ -78,6 +78,9 @@ extern "C" {
 #define CONF_WIFI_WPA3_SAE_PWE               "WifiWPA3SAEPWE"
 #define CONF_WIFI_WPA3_SAE_CHECK_MFP         "WifiWPA3SAECheckMFP"
 
+#define CONF_WIFI_WMT_ENABLE_SEQUENCE        "WifiWMTEnableSequence"
+#define CONF_WIFI_WMT_DISABLE_SEQUENCE       "WifiWMTDisableSequence"
+
 #define CONF_OPTION_CONFIG                   "config"
 #define CONF_OPTION_DEBUG                    "debug"
 #define CONF_OPTION_DEVICE                   "device"

--- a/connman/include/technology.h
+++ b/connman/include/technology.h
@@ -65,6 +65,8 @@ struct connman_technology_driver {
 	int (*set_regdom) (struct connman_technology *technology,
 						const char *alpha2);
 	void (*set_offline) (bool offline);
+	int (*set_tethering_prepare) (struct connman_technology *technology,
+				bool enabled);
 };
 
 int connman_technology_driver_register(struct connman_technology_driver *driver);

--- a/connman/plugins/sailfish_wifi.c
+++ b/connman/plugins/sailfish_wifi.c
@@ -106,8 +106,9 @@
 #define NETWORK_KEY_WIFI_SAE_PWE                "WiFi.SAEPWE"
 #define NETWORK_KEY_WIFI_SAE_CHECK_MFP          "WiFi.SAECheckMFP"
 
-
 #define NETWORK_EAP_DEFAULT                     "default"
+
+#define WMTWIFI_PATH				"/dev/wmtWifi"
 
 enum supplicant_events {
 	SUPPLICANT_EVENT_VALID,
@@ -322,6 +323,9 @@ struct wifi_plugin {
 	gulong supplicant_event_id[SUPPLICANT_EVENT_COUNT];
 	struct connman_technology *tech;
 	gboolean running;
+	gboolean wmtWiFi;
+	gboolean tethering_pending;
+	int tethering_index;
 	GSList *devices;
 };
 
@@ -3796,8 +3800,6 @@ static int wifi_device_on_start(struct wifi_device *dev)
 
 static void wifi_device_bridge_check(struct wifi_device *dev)
 {
-	DBG("");
-
 	if ((dev->iff & IFF_LOWER_UP) && dev->tethering &&
 					dev->bridge && !dev->bridged) {
 		DBG("index %d bridge %s", dev->ifi, dev->bridge);
@@ -4729,6 +4731,20 @@ static int wifi_plugin_set_tethering(struct wifi_plugin *plugin,
 				turning_tethering_on = TRUE;
 			} else if (iface && iface->valid && (iface->caps.modes &
 					GSUPPLICANT_INTERFACE_CAPS_MODES_AP)) {
+				/*
+				 * A wmtWifi device and expecting a separate AP
+				 * interface (device).
+				 */
+				if (plugin->wmtWiFi &&
+						plugin->tethering_pending) {
+					if (plugin->tethering_index != dev->ifi)
+						continue;
+
+					DBG("Found new AP interface index %d",
+								dev->ifi);
+					plugin->tethering_pending = false;
+				}
+
 				ap_dev = dev;
 			}
 		}
@@ -4754,10 +4770,15 @@ static int wifi_plugin_set_tethering(struct wifi_plugin *plugin,
 		for (l = plugin->devices; l; l = l->next) {
 			struct wifi_device *dev = l->data;
 
+			/* Skip reset on non-tethering devices */
+			if (!dev->tethering)
+				continue;
+
 			dev->tethering = NULL;
 			wifi_device_scan_check(dev);
 			wifi_device_on_start(dev);
 		}
+		plugin->tethering_index = 0;
 		connman_technology_tethering_notify(plugin->tech, false);
 		return 0;
 	}
@@ -4815,6 +4836,8 @@ static struct wifi_plugin *wifi_plugin_new(void)
 	wpa3_support = convert_wpa3_support(wpa3_support_str);
 	DBG("Set WPA3 support level to %d/%s", wpa3_support, wpa3_support_str);
 	gsupplicant_set_wpa3_support(plugin->supplicant, wpa3_support);
+
+	plugin->wmtWiFi = g_file_test(WMTWIFI_PATH, G_FILE_TEST_EXISTS);
 
 	return plugin;
 }
@@ -4887,20 +4910,119 @@ static int wifi_tech_driver_set_tethering(struct connman_technology *tech,
 				const char *ident, const char *passphrase,
 				const char *bridge, bool enabled)
 {
-	if (wifi_plugin && wifi_plugin->tech) {
-		GASSERT(wifi_plugin->tech == tech);
-		return wifi_plugin_set_tethering(wifi_plugin, ident,
-					passphrase, bridge, enabled);
+	if (!wifi_plugin || !wifi_plugin->tech)
+		return -EFAULT;
+
+	GASSERT(wifi_plugin->tech == tech);
+
+	return wifi_plugin_set_tethering(wifi_plugin, ident, passphrase, bridge,
+						enabled);
+}
+
+#include <fcntl.h>
+
+static int write_to_fd(int fd, const char cmd)
+{
+	if (write(fd, &cmd, 1) != 1) {
+		connman_error("cannot write \"%c\" to fd %d", cmd, fd);
+		return -errno;
 	}
-	return (-EFAULT);
+
+	return 0;
+}
+
+static int send_wmtWifi_sequence(struct connman_technology *technology,
+								bool enabled)
+{
+	const char *sequence;
+	int err = 0;
+	int fd;
+	int i;
+
+	sequence = connman_setting_get_string(enabled ?
+						CONF_WIFI_WMT_ENABLE_SEQUENCE :
+						CONF_WIFI_WMT_DISABLE_SEQUENCE);
+	if (!sequence) {
+		connman_warn("No %s sequence configured for wmtWifi", enabled ?
+						"enable" : "disable");
+		return -ENOENT;
+	}
+
+	fd = open(WMTWIFI_PATH, O_RDWR|O_SYNC);
+	if (fd < 0) {
+		connman_error("Cannot open wmtWifi device %s: %s", WMTWIFI_PATH,
+							strerror(errno));
+		return -EACCES;
+	}
+
+	for (i = 0; i < strlen(sequence); i++) {
+		err = write_to_fd(fd, sequence[i]);
+		if (err)
+			break;
+
+	}
+
+	close(fd);
+
+	DBG("%s sequence %s", sequence, err ? "failed" : "sent");
+
+	return err;
+}
+
+static bool is_wmtWiFi(struct connman_technology *tech)
+{
+	return connman_technology_get_type(tech) == CONNMAN_SERVICE_TYPE_WIFI &&
+							wifi_plugin->wmtWiFi;
+}
+
+static int wifi_tech_driver_set_tethering_prepare(
+				struct connman_technology *tech, bool enabled)
+{
+	int err;
+
+	if (!wifi_plugin || !wifi_plugin->tech)
+		return -EINVAL;
+
+	GASSERT(wifi_plugin->tech == tech);
+
+	if (!is_wmtWiFi(tech))
+		return -ENODEV;
+
+	err = send_wmtWifi_sequence(tech, enabled);
+	if (err) {
+		connman_error("Failed to prepare for tethering: %d/%s", err,
+						strerror(-err));
+		return -EFAULT;
+	}
+
+	wifi_plugin->tethering_pending = enabled;
+
+	return -EINPROGRESS;
+}
+
+static void wifi_tech_driver_add_interface(struct connman_technology *tech,
+				int index, const char *name, const char *ident)
+{
+	if (!wifi_plugin || !wifi_plugin->tech)
+		return;
+
+	GASSERT(wifi_plugin->tech == tech);
+
+	if (!wifi_plugin->tethering_pending)
+		return;
+
+	DBG("New tethering interface %d/%s", index, name);
+	wifi_plugin->tethering_index = index;
 }
 
 static struct connman_technology_driver wifi_tech_driver = {
-	.name		= "wifi",
-	.type		= CONNMAN_SERVICE_TYPE_WIFI,
-	.probe		= wifi_tech_driver_probe,
-	.remove		= wifi_tech_driver_remove,
-	.set_tethering	= wifi_tech_driver_set_tethering
+	.name			= "wifi",
+	.type			= CONNMAN_SERVICE_TYPE_WIFI,
+	.probe			= wifi_tech_driver_probe,
+	.add_interface		= wifi_tech_driver_add_interface,
+	.remove			= wifi_tech_driver_remove,
+	.set_tethering		= wifi_tech_driver_set_tethering,
+	.set_tethering_prepare	= wifi_tech_driver_set_tethering_prepare,
 };
 
 static int sailfish_wifi_init(void)

--- a/connman/src/setting.c
+++ b/connman/src/setting.c
@@ -96,6 +96,8 @@ static struct {
 	char *localtime;
 	char *wifi_wpa3_support;
 	char *wifi_wpa3_sae_pwe;
+	char *wifi_wmt_enable_sequence;
+	char *wifi_wmt_disable_sequence;
 	unsigned int *auto_connect;
 	unsigned int *favorite_techs;
 	unsigned int *preferred_techs;
@@ -180,6 +182,8 @@ enum option_val {
 	CONF_WIFI_WPA3_SUPPORT_VAL,
 	CONF_WIFI_WPA3_SAE_PWE_VAL,
 	CONF_WIFI_WPA3_SAE_CHECK_MFP_VAL,
+	CONF_WIFI_WMT_ENABLE_SEQUENCE_VAL,
+	CONF_WIFI_WMT_DISABLE_SEQUENCE_VAL,
 };
 
 enum option_type {
@@ -331,6 +335,12 @@ struct {
 	{CONF_WIFI_WPA3_SAE_CHECK_MFP,
 					CONF_WIFI_WPA3_SAE_CHECK_MFP_VAL,
 					CONF_TYPE_BOOL},
+	{CONF_WIFI_WMT_ENABLE_SEQUENCE,
+					CONF_WIFI_WMT_ENABLE_SEQUENCE_VAL,
+					CONF_TYPE_CHAR},
+	{CONF_WIFI_WMT_DISABLE_SEQUENCE,
+					CONF_WIFI_WMT_DISABLE_SEQUENCE_VAL,
+					CONF_TYPE_CHAR},
 	{ 0 }
 };
 
@@ -405,6 +415,12 @@ const char *connman_setting_get_string(const char *key)
 
 	if (g_str_equal(key, CONF_WIFI_WPA3_SAE_PWE))
 		return connman_settings.wifi_wpa3_sae_pwe;
+
+	if (g_str_equal(key, CONF_WIFI_WMT_ENABLE_SEQUENCE))
+		return connman_settings.wifi_wmt_enable_sequence;
+
+	if (g_str_equal(key, CONF_WIFI_WMT_DISABLE_SEQUENCE))
+		return connman_settings.wifi_wmt_disable_sequence;
 
 	return NULL;
 }
@@ -890,6 +906,12 @@ static void read_config_value(GKeyFile *config, const char *key, bool append)
 		str_ptr = &connman_settings.wifi_wpa3_sae_pwe;
 		check_cb = check_wpa3_sae_pwe;
 		break;
+	case CONF_WIFI_WMT_ENABLE_SEQUENCE_VAL:
+		str_ptr = &connman_settings.wifi_wmt_enable_sequence;
+		break;
+	case CONF_WIFI_WMT_DISABLE_SEQUENCE_VAL:
+		str_ptr = &connman_settings.wifi_wmt_disable_sequence;
+		break;
 
 	/* str list */
 	case CONF_FALLBACK_TIMESERVERS_VAL:
@@ -1264,6 +1286,9 @@ void __connman_setting_cleanup()
 	g_free(connman_settings.user_storage_dir);
 	g_free(connman_settings.vendor_class_id);
 	g_free(connman_settings.localtime);
+	g_free(connman_settings.wifi_wpa3_sae_pwe);
+	g_free(connman_settings.wifi_wmt_enable_sequence);
+	g_free(connman_settings.wifi_wmt_disable_sequence);
 
 	g_free(connman_settings.auto_connect);
 	g_free(connman_settings.favorite_techs);

--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -34,6 +34,7 @@
 #include "connman.h"
 
 #define DELAYED_TIMEOUT 300
+#define DELAYED_TETHERING_TIMEOUT 100
 
 static DBusConnection *connection;
 
@@ -70,6 +71,7 @@ struct connman_technology {
 	bool connected;
 
 	bool tethering;
+	bool tethering_pending;
 	bool tethering_persistent; /* Tells the save status, needed
 					      * as offline mode might set
 					      * tethering OFF.
@@ -91,6 +93,8 @@ struct connman_technology {
 	bool softblocked;
 	bool hardblocked;
 	bool dbus_registered;
+
+	guint tethering_delayed_id;
 };
 
 static GSList *driver_list = NULL;
@@ -338,6 +342,37 @@ int connman_technology_tethering_notify(struct connman_technology *technology,
 	return 0;
 }
 
+static int set_tethering_prepare(struct connman_technology *technology,
+				bool enabled)
+{
+	GSList *tech_drivers;
+
+	DBG("");
+
+	for (tech_drivers = technology->driver_list; tech_drivers;
+				tech_drivers = g_slist_next(tech_drivers)) {
+		struct connman_technology_driver *driver =
+						tech_drivers->data;
+
+		if (!driver || !driver->set_tethering_prepare)
+			continue;
+
+		if (driver->set_tethering_prepare(technology, enabled)
+							!= -EINPROGRESS)
+			continue;
+
+		technology->tethering_pending = enabled;
+		DBG("called tethering prepare on %p", technology);
+
+		if (enabled) {
+			DBG("wait for the interface to come up");
+			return -EINPROGRESS;
+		}
+	}
+
+	return 0;
+}
+
 static int set_tethering(struct connman_technology *technology,
 				bool enabled)
 {
@@ -360,6 +395,14 @@ static int set_tethering(struct connman_technology *technology,
 	if (technology->type == CONNMAN_SERVICE_TYPE_WIFI &&
 	    (!ident || !passphrase))
 		return -EINVAL;
+
+	/* Run preparations before enabling only */
+	if (!technology->tethering_pending && enabled) {
+		DBG("run tethering pre-action");
+		err = set_tethering_prepare(technology, enabled);
+		if (err)
+			return err;
+	}
 
 	/*
 	 * Notify about tethering being turned on before it actually gets
@@ -385,6 +428,14 @@ static int set_tethering(struct connman_technology *technology,
 			result = err;
 	}
 
+	/* Run post-action (as prepare cb) after disabling tethering. */
+	if (!technology->tethering_pending && !enabled) {
+		DBG("run tethering post-action");
+		err = set_tethering_prepare(technology, enabled);
+		if (err && err != -EINPROGRESS)
+			return err;
+	}
+
 	/*
 	 * Let notificants know that we have failed to turn tethering on.
 	 * Note that we won't be able to do that in case if the driver
@@ -396,6 +447,30 @@ static int set_tethering(struct connman_technology *technology,
 		__connman_notifier_tethering_changed(technology, FALSE);
 
 	return result;
+}
+
+gboolean set_tethering_delayed(gpointer user_data)
+{
+	struct connman_technology *technology = user_data;
+	int err;
+
+	DBG("");
+
+	if (!technology->tethering_pending) {
+		DBG("technology %p not pending tethering", technology);
+
+		technology->tethering_delayed_id = 0;
+		return G_SOURCE_REMOVE;
+	}
+
+	err = set_tethering(technology, true);
+	if (err < 0 && err != -EINPROGRESS) {
+		DBG("failed to do delayed enabling of tethering");
+	}
+
+	technology->tethering_pending = false;
+	technology->tethering_delayed_id = 0;
+	return G_SOURCE_REMOVE;
 }
 
 void connman_technology_regdom_notify(struct connman_technology *technology,
@@ -1266,10 +1341,12 @@ static DBusMessage *set_property(DBusConnection *conn,
 		}
 
 		err = set_tethering(technology, tethering);
-		if (err < 0)
+		if (err < 0 && err != -EINPROGRESS)
 			return __connman_error_failed(msg, -err);
 
 		technology->tethering_persistent = tethering;
+		DBG("tech %p tethering_persistent %d", technology,
+						technology->tethering_persistent);
 
 		technology_save(technology);
 
@@ -1747,8 +1824,29 @@ void __connman_technology_add_interface(enum connman_service_type type,
 	 * At this point we can try to enable tethering automatically as
 	 * now the interfaces are set properly.
 	 */
-	if (technology->tethering_persistent)
-		enable_tethering(technology);
+	if (technology->tethering_persistent) {
+		/*
+		 * If the technology has tethering awaiting for an interface
+		 * to come up do it instead of persistent tethering enabling
+		 * via enable_tethering() by scheduling the event for later
+		 * after the technology plugin has registered the interfaces
+		 * after the interface has been added. Doing tethering enable
+		 * here would be too early for the plugins and the interface
+		 * selected would be a wrong one.
+		 */
+		if (technology->tethering_pending) {
+			DBG("start delayed tethering");
+			if (technology->tethering_delayed_id)
+				g_source_remove(
+					technology->tethering_delayed_id);
+
+			technology->tethering_delayed_id = g_timeout_add(
+					DELAYED_TETHERING_TIMEOUT,
+					set_tethering_delayed, technology);
+		} else {
+			enable_tethering(technology);
+		}
+	}
 
 out:
 	g_free(name);


### PR DESCRIPTION
Add pre/post operation support when enabling tethering. This triggers, with -EINPROGRESS error a delayed start of tethering so the newly brought up interfaces can be added and the plugin has time to react to them.

A two new options are added to settings in order to specify the wmtWifi device sequence to be sent. 

Sailfish OS WiFi plugin records the newly created AP interface index and uses that device when tethering is pending for further actions.