### PR TITLE
Add a wmtWifi dual mode property to D-Bus and use it in WLAN plugin

### DIFF
--- a/connman/include/setting.h
+++ b/connman/include/setting.h
@@ -80,6 +80,7 @@ extern "C" {
 
 #define CONF_WIFI_WMT_ENABLE_SEQUENCE        "WifiWMTEnableSequence"
 #define CONF_WIFI_WMT_DISABLE_SEQUENCE       "WifiWMTDisableSequence"
+#define CONF_WIFI_WMT_DUAL_MODE              "WifiWMTDualMode"
 
 #define CONF_OPTION_CONFIG                   "config"
 #define CONF_OPTION_DEBUG                    "debug"

--- a/connman/plugins/sailfish_wifi.c
+++ b/connman/plugins/sailfish_wifi.c
@@ -5325,6 +5325,13 @@ static int wifi_tech_driver_set_tethering_prepare(
 	if (!is_wmtWiFi(tech))
 		return -ENODEV;
 
+	/*
+	 * Prevent to send multiple enable sequences. Allow to always send
+	 * disable sequence.
+	 */
+	if (enabled && wifi_plugin->tethering_pending)
+		return -EALREADY;
+
 	err = send_wmtWifi_sequence(tech, enabled);
 	if (err) {
 		connman_error("Failed to prepare for tethering: %d/%s", err,

--- a/connman/plugins/sailfish_wifi.c
+++ b/connman/plugins/sailfish_wifi.c
@@ -321,6 +321,7 @@ struct wifi_device {
 	GSList *active_scans;
 	unsigned int watch;
 	struct connman_technology *tethering;
+	bool enable_after_tethering;
 	gboolean bridged;
 	char *bridge;
 	unsigned int bridge_watch;
@@ -335,6 +336,7 @@ struct wifi_plugin {
 	struct connman_technology *tech;
 	gboolean running;
 	gboolean wmtWiFi;
+	gboolean wmtWiFiDualMode;
 	gboolean tethering_pending;
 	int tethering_index;
 	GSList *devices;
@@ -5000,6 +5002,31 @@ static struct connman_device_driver wifi_device_driver = {
  * Plugin
  *==========================================================================*/
 
+static void wifi_plugin_toggle_devices(struct wifi_plugin *plugin, bool enable,
+						struct wifi_device *exclude)
+{
+	GSList *l;
+	for (l = plugin->devices; l; l = l->next) {
+		struct wifi_device *dev = l->data;
+		if (dev == exclude || dev->tethering)
+			continue;
+
+		if (enable) {
+			if (dev->enable_after_tethering) {
+				DBG("enable %p", dev);
+				dev->enable_after_tethering = false;
+				wifi_device_enable(dev);
+				wifi_device_scan_check(dev);
+				wifi_device_on_start(dev);
+			}
+		} else {
+			DBG("disable %p", dev);
+			dev->enable_after_tethering = true;
+			wifi_device_disable(dev);
+		}
+	}
+}
+
 static int wifi_plugin_set_tethering(struct wifi_plugin *plugin,
 				const char *ssid, const char *passphrase,
 				const char *bridge, bool enabled)
@@ -5046,6 +5073,14 @@ static int wifi_plugin_set_tethering(struct wifi_plugin *plugin,
 				DBG("already tethering");
 				return (-EALREADY);
 			} else {
+				/*
+				 * Disable all except the tethering dev when the
+				 * dual mode is not enabled.
+				 */
+				if (plugin->wmtWiFi && !plugin->wmtWiFiDualMode)
+					wifi_plugin_toggle_devices(plugin,
+								false, ap_dev);
+
 				/* Start tethering */
 				return wifi_device_tether_start(ap_dev,
 							plugin->tech, bridge,
@@ -5072,6 +5107,14 @@ static int wifi_plugin_set_tethering(struct wifi_plugin *plugin,
 		}
 		plugin->tethering_index = 0;
 		connman_technology_tethering_notify(plugin->tech, false);
+
+		/*
+		 * Re-enable devices that were disabled when tethering was
+		 * enabled in non-dual mode.
+		 */
+		if (plugin->wmtWiFi && !plugin->wmtWiFiDualMode)
+			wifi_plugin_toggle_devices(plugin, true, NULL);
+
 		return 0;
 	}
 }
@@ -5130,6 +5173,8 @@ static struct wifi_plugin *wifi_plugin_new(void)
 	gsupplicant_set_wpa3_support(plugin->supplicant, wpa3_support);
 
 	plugin->wmtWiFi = g_file_test(WMTWIFI_PATH, G_FILE_TEST_EXISTS);
+	plugin->wmtWiFiDualMode = connman_setting_get_bool(
+						CONF_WIFI_WMT_DUAL_MODE);
 
 	return plugin;
 }

--- a/connman/src/manager.c
+++ b/connman/src/manager.c
@@ -64,6 +64,7 @@ static DBusMessage *get_properties(DBusConnection *conn,
 	DBusMessage *reply;
 	DBusMessageIter array, dict;
 	dbus_bool_t offlinemode;
+	dbus_bool_t wmtWifiDualMode;
 	dbus_uint32_t uint32_value;
 	const char *str;
 	const char *ipv4_status_url;
@@ -110,6 +111,10 @@ static DBusMessage *get_properties(DBusConnection *conn,
 
 	connman_dbus_dict_append_basic(&dict, "WiFiWPA3Support",
 						DBUS_TYPE_STRING, &str);
+
+	wmtWifiDualMode = connman_setting_get_bool(CONF_WIFI_WMT_DUAL_MODE);
+	connman_dbus_dict_append_basic(&dict, "WiFiWMTDualMode",
+					DBUS_TYPE_BOOLEAN, &wmtWifiDualMode);
 
 	connman_dbus_dict_close(&array, &dict);
 

--- a/connman/src/setting.c
+++ b/connman/src/setting.c
@@ -122,6 +122,7 @@ static struct {
 	bool default_mdns_configuration;
 	bool tethering_mdns_configuration;
 	bool wifi_wpa3_sae_check_mfp;
+	bool wifi_wmt_dual_mode;
 	mode_t storage_root_permissions;
 	mode_t storage_dir_permissions;
 	mode_t storage_file_permissions;
@@ -184,6 +185,7 @@ enum option_val {
 	CONF_WIFI_WPA3_SAE_CHECK_MFP_VAL,
 	CONF_WIFI_WMT_ENABLE_SEQUENCE_VAL,
 	CONF_WIFI_WMT_DISABLE_SEQUENCE_VAL,
+	CONF_WIFI_WMT_DUAL_MODE_VAL,
 };
 
 enum option_type {
@@ -341,6 +343,9 @@ struct {
 	{CONF_WIFI_WMT_DISABLE_SEQUENCE,
 					CONF_WIFI_WMT_DISABLE_SEQUENCE_VAL,
 					CONF_TYPE_CHAR},
+	{CONF_WIFI_WMT_DUAL_MODE,
+					CONF_WIFI_WMT_DUAL_MODE_VAL,
+					CONF_TYPE_BOOL},
 	{ 0 }
 };
 
@@ -477,6 +482,9 @@ bool connman_setting_get_bool(const char *key)
 
 	if (g_str_equal(key, CONF_WIFI_WPA3_SAE_CHECK_MFP))
 		return connman_settings.wifi_wpa3_sae_check_mfp;
+
+	if (g_str_equal(key, CONF_WIFI_WMT_DUAL_MODE))
+		return connman_settings.wifi_wmt_dual_mode;
 
 	return false;
 }
@@ -868,6 +876,9 @@ static void read_config_value(GKeyFile *config, const char *key, bool append)
 		break;
 	case CONF_WIFI_WPA3_SAE_CHECK_MFP_VAL:
 		bool_ptr = &connman_settings.wifi_wpa3_sae_check_mfp;
+		break;
+	case CONF_WIFI_WMT_DUAL_MODE_VAL:
+		bool_ptr = &connman_settings.wifi_wmt_dual_mode;
 		break;
 
 	/* str */

--- a/connman/src/technology.c
+++ b/connman/src/technology.c
@@ -357,6 +357,11 @@ static int set_tethering_prepare(struct connman_technology *technology,
 		if (!driver || !driver->set_tethering_prepare)
 			continue;
 
+		if (enabled && technology->tethering_pending) {
+			DBG("skip tethering prepare, already pending");
+			continue;
+		}
+
 		if (driver->set_tethering_prepare(technology, enabled)
 							!= -EINPROGRESS)
 			continue;


### PR DESCRIPTION
Add a WifiWMTDualMode boolean configuration option and expose it as a read only D-Bus property. This can be used to define the Sailfish OS WiFi plugin behavior with wmtWifi devices when tethering. Value for the option is by default `false` that defines dual mode not being used and when tethering is enabled the normal WLAN device is disabled in favor of using the AP device. In dual mode (`true`) WLAN device remains active and is not disabled/enabled when AP mode is activated.

The default behavior is, thus, identical to what it is without wmtWifi device. This does not require any UI changes but allows to enable the dual mode in configuration when making the UI changes.